### PR TITLE
Added functionality to move windows with MouseMove instead of MouseDown

### DIFF
--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -10,6 +10,7 @@ static const int kResizeFilterInterval = 4;
 }
 
 - (int)modifierFlags;
+- (BOOL)useMouseMove;
 
 - (void)initModifierMenuItems;
 - (IBAction)modifierToggle:(id)sender;
@@ -21,5 +22,6 @@ static const int kResizeFilterInterval = 4;
 @property (weak) IBOutlet NSMenuItem *ctrlMenu;
 @property (weak) IBOutlet NSMenuItem *shiftMenu;
 @property (weak) IBOutlet NSMenuItem *disabledMenu;
+@property (weak) IBOutlet NSMenuItem *useMouseMoveMenu;
 
 @end

--- a/easy-move-resize/EMRPreferences.h
+++ b/easy-move-resize/EMRPreferences.h
@@ -12,6 +12,7 @@
 #define EMRPreferences_h
 
 #define MODIFIER_FLAGS_DEFAULTS_KEY @"ModifierFlags"
+#define USE_MOUSE_MOVE_DEFAULTS_KEY @"UseMouseMove"
 #define CTRL_KEY @"CTRL"
 #define SHIFT_KEY @"SHIFT"
 #define CAPS_KEY @"CAPS" // CAPS lock
@@ -24,8 +25,10 @@
 
 // Get the modifier flags from the standard preferences
 + (int) modifierFlags;
++ (BOOL) useMouseMove;
 // Store a modifier flag string in the preferences. (e.g. "CTRL,CMD"
 + (void) setModifierFlagString:(NSString*)flagString;
++ (void) setUseMouseMove:(BOOL)enabled;
 
 + (void) setModifierKey:(NSString*)singleFlagString enabled:(BOOL)enabled;
 + (NSSet*) getFlagStringSet;

--- a/easy-move-resize/EMRPreferences.m
+++ b/easy-move-resize/EMRPreferences.m
@@ -33,6 +33,15 @@
     [[NSUserDefaults standardUserDefaults] setObject:flagString forKey:MODIFIER_FLAGS_DEFAULTS_KEY];
 }
 
++ (BOOL) useMouseMove {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    return [defaults boolForKey:USE_MOUSE_MOVE_DEFAULTS_KEY];
+}
+
++ (void)setUseMouseMove:(BOOL)enabled {
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:USE_MOUSE_MOVE_DEFAULTS_KEY];
+}
+
 
 + (void)setModifierKey:(NSString *)singleFlagString enabled:(BOOL)enabled {
     singleFlagString = [singleFlagString uppercaseString];

--- a/easy-move-resize/en.lproj/MainMenu.xib
+++ b/easy-move-resize/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1509" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12121" systemVersion="16F2073" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -617,7 +617,8 @@
                                     <action selector="performMiniaturize:" target="-1" id="37"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Zoom" id="239">
+                            <menuItem title="Zoom" keyEquivalent="m" id="239">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
                                     <action selector="performZoom:" target="-1" id="240"/>
                                 </connections>
@@ -656,6 +657,12 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="toggleDisabled:" target="494" id="agH-Tw-ei0"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Move without press" id="8dc-ly-gU1" userLabel="Use Mouse Move Menu">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="useMouseMoveToggle:" target="494" id="sWH-Wa-hyw"/>
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="a5T-MQ-31B"/>
@@ -698,7 +705,7 @@
                     </connections>
                 </menuItem>
             </items>
-            <point key="canvasLocation" x="-156" y="484.5"/>
+            <point key="canvasLocation" x="-156.5" y="474.5"/>
         </menu>
         <customObject id="494" customClass="EMRAppDelegate">
             <connections>
@@ -708,6 +715,7 @@
                 <outlet property="disabledMenu" destination="Q0w-G0-Ppy" id="D3v-HP-HjG"/>
                 <outlet property="shiftMenu" destination="SZL-bI-dng" id="YZk-pM-c3k"/>
                 <outlet property="statusMenu" destination="obP-gH-pam" id="YfI-Jt-Lpf"/>
+                <outlet property="useMouseMoveMenu" destination="8dc-ly-gU1" id="tiw-1T-5jt"/>
             </connections>
         </customObject>
         <customObject id="420" customClass="NSFontManager"/>

--- a/easy-move-resize/en.lproj/MainMenu.xib
+++ b/easy-move-resize/en.lproj/MainMenu.xib
@@ -659,7 +659,7 @@
                         <action selector="toggleDisabled:" target="494" id="agH-Tw-ei0"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Move without press" id="8dc-ly-gU1" userLabel="Use Mouse Move Menu">
+                <menuItem title="Hover move" id="8dc-ly-gU1" userLabel="Use Mouse Move Menu">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="useMouseMoveToggle:" target="494" id="sWH-Wa-hyw"/>


### PR DESCRIPTION
See https://github.com/dmarcotte/easy-move-resize/issues/21

Added functionality to move windows like Zooom/2.
No functionality to resize windows without pressing right mouse button.