### PR TITLE
WIP: Move only tracking

### DIFF
--- a/easy-move-resize.xcodeproj/project.pbxproj
+++ b/easy-move-resize.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		52B5E8F61C513E3D0055C181 /* EMRPreferences.m in Sources */ = {isa = PBXBuildFile; fileRef = 52B5E8F51C513E3D0055C181 /* EMRPreferences.m */; };
+		5ABC799320CD78C100B22173 /* EMRHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ABC799220CD78C100B22173 /* EMRHelper.m */; };
+		5ABC799620CD78D900B22173 /* EMRHelperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ABC799020CD6D0E00B22173 /* EMRHelperTest.m */; };
+		5ABC799820CD79BD00B22173 /* EMRHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ABC799220CD78C100B22173 /* EMRHelper.m */; };
 		65CF01651F229C34002259F2 /* EMRPreferencesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 65CF01641F229C34002259F2 /* EMRPreferencesTest.m */; };
 		6ED47B65183BF3E800859244 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6ED47B64183BF3E800859244 /* Cocoa.framework */; };
 		6ED47B6F183BF3E800859244 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6ED47B6D183BF3E800859244 /* InfoPlist.strings */; };
@@ -34,6 +37,9 @@
 /* Begin PBXFileReference section */
 		52B5E8F51C513E3D0055C181 /* EMRPreferences.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EMRPreferences.m; sourceTree = "<group>"; };
 		52B5E8F81C513E7A0055C181 /* EMRPreferences.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EMRPreferences.h; sourceTree = "<group>"; };
+		5ABC799020CD6D0E00B22173 /* EMRHelperTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMRHelperTest.m; sourceTree = "<group>"; };
+		5ABC799220CD78C100B22173 /* EMRHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMRHelper.m; sourceTree = "<group>"; };
+		5ABC799720CD78F000B22173 /* EMRHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EMRHelper.h; sourceTree = "<group>"; };
 		65CF01621F229C34002259F2 /* easy-move-resizeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "easy-move-resizeTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		65CF01641F229C34002259F2 /* EMRPreferencesTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMRPreferencesTest.m; sourceTree = "<group>"; };
 		65CF01661F229C34002259F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -84,6 +90,7 @@
 			isa = PBXGroup;
 			children = (
 				65CF01641F229C34002259F2 /* EMRPreferencesTest.m */,
+				5ABC799020CD6D0E00B22173 /* EMRHelperTest.m */,
 				65CF01661F229C34002259F2 /* Info.plist */,
 			);
 			path = "easy-move-resizeTests";
@@ -145,6 +152,8 @@
 				F907AEB04B0AF90540F6EF00 /* EMRMoveResize.m */,
 				52B5E8F51C513E3D0055C181 /* EMRPreferences.m */,
 				52B5E8F81C513E7A0055C181 /* EMRPreferences.h */,
+				5ABC799220CD78C100B22173 /* EMRHelper.m */,
+				5ABC799720CD78F000B22173 /* EMRHelper.h */,
 			);
 			path = "easy-move-resize";
 			sourceTree = "<group>";
@@ -261,6 +270,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5ABC799620CD78D900B22173 /* EMRHelperTest.m in Sources */,
+				5ABC799820CD79BD00B22173 /* EMRHelper.m in Sources */,
 				65CF01651F229C34002259F2 /* EMRPreferencesTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -270,6 +281,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6ED47B71183BF3E800859244 /* main.m in Sources */,
+				5ABC799320CD78C100B22173 /* EMRHelper.m in Sources */,
 				52B5E8F61C513E3D0055C181 /* EMRPreferences.m in Sources */,
 				6ED47B78183BF3E800859244 /* EMRAppDelegate.m in Sources */,
 				F907A25928093AED2C89550E /* EMRMoveResize.m in Sources */,

--- a/easy-move-resize.xcodeproj/project.pbxproj
+++ b/easy-move-resize.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		52B5E8F61C513E3D0055C181 /* EMRPreferences.m in Sources */ = {isa = PBXBuildFile; fileRef = 52B5E8F51C513E3D0055C181 /* EMRPreferences.m */; };
+		5A6B5BCC20D1720000F7A36C /* EMRPreferencesController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6B5BCA20D1720000F7A36C /* EMRPreferencesController.m */; };
+		5A6B5BCD20D1720000F7A36C /* EMRPreferencesController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A6B5BCB20D1720000F7A36C /* EMRPreferencesController.xib */; };
 		5ABC799320CD78C100B22173 /* EMRHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ABC799220CD78C100B22173 /* EMRHelper.m */; };
 		5ABC799620CD78D900B22173 /* EMRHelperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ABC799020CD6D0E00B22173 /* EMRHelperTest.m */; };
 		5ABC799820CD79BD00B22173 /* EMRHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ABC799220CD78C100B22173 /* EMRHelper.m */; };
@@ -37,6 +39,9 @@
 /* Begin PBXFileReference section */
 		52B5E8F51C513E3D0055C181 /* EMRPreferences.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EMRPreferences.m; sourceTree = "<group>"; };
 		52B5E8F81C513E7A0055C181 /* EMRPreferences.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EMRPreferences.h; sourceTree = "<group>"; };
+		5A6B5BC920D1720000F7A36C /* EMRPreferencesController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EMRPreferencesController.h; sourceTree = "<group>"; };
+		5A6B5BCA20D1720000F7A36C /* EMRPreferencesController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMRPreferencesController.m; sourceTree = "<group>"; };
+		5A6B5BCB20D1720000F7A36C /* EMRPreferencesController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EMRPreferencesController.xib; sourceTree = "<group>"; };
 		5ABC799020CD6D0E00B22173 /* EMRHelperTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMRHelperTest.m; sourceTree = "<group>"; };
 		5ABC799220CD78C100B22173 /* EMRHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMRHelper.m; sourceTree = "<group>"; };
 		5ABC799720CD78F000B22173 /* EMRHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EMRHelper.h; sourceTree = "<group>"; };
@@ -154,6 +159,9 @@
 				52B5E8F81C513E7A0055C181 /* EMRPreferences.h */,
 				5ABC799220CD78C100B22173 /* EMRHelper.m */,
 				5ABC799720CD78F000B22173 /* EMRHelper.h */,
+				5A6B5BC920D1720000F7A36C /* EMRPreferencesController.h */,
+				5A6B5BCA20D1720000F7A36C /* EMRPreferencesController.m */,
+				5A6B5BCB20D1720000F7A36C /* EMRPreferencesController.xib */,
 			);
 			path = "easy-move-resize";
 			sourceTree = "<group>";
@@ -214,7 +222,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = EMR;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = "Daniel Marcotte";
 				TargetAttributes = {
 					65CF01611F229C34002259F2 = {
@@ -260,6 +268,7 @@
 				6ED47B7B183BF3E800859244 /* MainMenu.xib in Resources */,
 				F907ABDDEEAF5BF83F0AF9EA /* readme.md in Resources */,
 				F907A53FB2CAEBEB31895CD2 /* contributing.md in Resources */,
+				5A6B5BCD20D1720000F7A36C /* EMRPreferencesController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -285,6 +294,7 @@
 				52B5E8F61C513E3D0055C181 /* EMRPreferences.m in Sources */,
 				6ED47B78183BF3E800859244 /* EMRAppDelegate.m in Sources */,
 				F907A25928093AED2C89550E /* EMRMoveResize.m in Sources */,
+				5A6B5BCC20D1720000F7A36C /* EMRPreferencesController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,12 +383,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -422,12 +434,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;

--- a/easy-move-resize.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/easy-move-resize.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -21,6 +21,7 @@ static const double kResizeFilterInterval = 0.04;
 @property (weak) IBOutlet NSMenuItem *altMenu;
 @property (weak) IBOutlet NSMenuItem *cmdMenu;
 @property (weak) IBOutlet NSMenuItem *ctrlMenu;
+@property (weak) IBOutlet NSMenuItem *fnMenu;
 @property (weak) IBOutlet NSMenuItem *shiftMenu;
 @property (weak) IBOutlet NSMenuItem *disabledMenu;
 

--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -2,8 +2,8 @@
 
 // these intervals feel good in experimentation, but maybe in the future we can measure how long
 // the move and resize increments are actually taking and adjust them dynamically for each move/resize?
-static const double kMoveFilterInterval = 0.02;
-static const double kResizeFilterInterval = 0.04;
+static const double kMoveFilterInterval = 0.01;
+static const double kResizeFilterInterval = 0.02;
 
 @interface EMRAppDelegate : NSObject <NSApplicationDelegate> {
     IBOutlet NSMenu *statusMenu;

--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -8,21 +8,14 @@ static const double kResizeFilterInterval = 0.02;
 @interface EMRAppDelegate : NSObject <NSApplicationDelegate> {
     IBOutlet NSMenu *statusMenu;
     NSStatusItem * statusItem;
-    int keyModifierFlags;
 }
 
-- (int)modifierFlags;
+- (int)moveModifierFlags;
+- (int)resizeModifierFlags;
 
-- (void)initModifierMenuItems;
-- (IBAction)modifierToggle:(id)sender;
-- (IBAction)resetModifiersToDefaults:(id)sender;
 - (IBAction)toggleDisabled:(id)sender;
+- (IBAction)showPreferences:(id)sender;
 
-@property (weak) IBOutlet NSMenuItem *altMenu;
-@property (weak) IBOutlet NSMenuItem *cmdMenu;
-@property (weak) IBOutlet NSMenuItem *ctrlMenu;
-@property (weak) IBOutlet NSMenuItem *fnMenu;
-@property (weak) IBOutlet NSMenuItem *shiftMenu;
 @property (weak) IBOutlet NSMenuItem *disabledMenu;
 
 @end

--- a/easy-move-resize/EMRAppDelegate.m
+++ b/easy-move-resize/EMRAppDelegate.m
@@ -119,17 +119,17 @@ bool startResizing(CGEventRef event, EMRMoveResize* moveResize) {
 
     NSSize wndSize = cSize;
 
-    if (clickPoint.x < wndSize.width/3) {
+    if (clickPoint.x < wndSize.width/2) {
         resizeSection.xResizeDirection = left;
-    } else if (clickPoint.x > 2*wndSize.width/3) {
+    } else if (clickPoint.x > wndSize.width/2) {
         resizeSection.xResizeDirection = right;
     } else {
         resizeSection.xResizeDirection = noX;
     }
 
-    if (clickPoint.y < wndSize.height/3) {
+    if (clickPoint.y < wndSize.height/2) {
         resizeSection.yResizeDirection = bottom;
-    } else  if (clickPoint.y > 2*wndSize.height/3) {
+    } else  if (clickPoint.y > wndSize.height/2) {
         resizeSection.yResizeDirection = top;
     } else {
         resizeSection.yResizeDirection = noY;

--- a/easy-move-resize/EMRAppDelegate.m
+++ b/easy-move-resize/EMRAppDelegate.m
@@ -310,6 +310,7 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     [_altMenu setState:0];
     [_cmdMenu setState:0];
     [_ctrlMenu setState:0];
+    [_fnMenu setState:0];
     [_shiftMenu setState:0];
     [_disabledMenu setState:0];
     NSSet* flags = [preferences getFlagStringSet];
@@ -321,6 +322,9 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     }
     if ([flags containsObject:CTRL_KEY]) {
         [_ctrlMenu setState:1];
+    }
+    if ([flags containsObject:FN_KEY]) {
+        [_fnMenu setState:1];
     }
     if ([flags containsObject:SHIFT_KEY]) {
         [_shiftMenu setState:1];
@@ -365,6 +369,7 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     [_altMenu setEnabled:enabled];
     [_cmdMenu setEnabled:enabled];
     [_ctrlMenu setEnabled:enabled];
+    [_fnMenu setEnabled:enabled];
     [_shiftMenu setEnabled:enabled];
 }
 

--- a/easy-move-resize/EMRAppDelegate.m
+++ b/easy-move-resize/EMRAppDelegate.m
@@ -44,7 +44,7 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
     bool modifiersDown = (flags & (keyModifierFlags)) == (keyModifierFlags);
 
-    int ignoredKeysMask = (kCGEventFlagMaskShift | kCGEventFlagMaskCommand | kCGEventFlagMaskAlphaShift | kCGEventFlagMaskAlternate | kCGEventFlagMaskControl) ^ keyModifierFlags;
+    int ignoredKeysMask = (kCGEventFlagMaskShift | kCGEventFlagMaskCommand | kCGEventFlagMaskAlphaShift | kCGEventFlagMaskAlternate | kCGEventFlagMaskControl | kCGEventFlagMaskSecondaryFn) ^ keyModifierFlags;
     
     if (flags & ignoredKeysMask) {
         // also ignore this event if we've got extra modifiers (i.e. holding down Cmd+Ctrl+Alt should not invoke our action)

--- a/easy-move-resize/EMRAppDelegate.m
+++ b/easy-move-resize/EMRAppDelegate.m
@@ -24,7 +24,7 @@ typedef enum : NSUInteger {
 }
 
 
-void startMoving(CGEventRef event, EMRMoveResize *moveResize) {
+void startTracking(CGEventRef event, EMRMoveResize *moveResize) {
     CGPoint mouseLocation = CGEventGetLocation(event);
     [moveResize setTracking:CACurrentMediaTime()];
 
@@ -68,7 +68,7 @@ void startMoving(CGEventRef event, EMRMoveResize *moveResize) {
 }
 
 
-void stop(EMRMoveResize* moveResize) {
+void stopTracking(EMRMoveResize* moveResize) {
     [moveResize setTracking:0];
 }
 
@@ -96,7 +96,7 @@ void keepMoving(CGEventRef event, EMRMoveResize* moveResize) {
 }
 
 
-bool startResizing(CGEventRef event, EMRMoveResize* moveResize) {
+bool determineResizeDirection(CGEventRef event, EMRMoveResize* moveResize) {
     AXUIElementRef _clickedWindow = [moveResize window];
 
     // on right click, record which direction we should resize in on the drag
@@ -262,13 +262,15 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
                 case moving:
                     // NSLog(@"idle -> moving");
-                    startMoving(event, moveResize);
+                    startTracking(event, moveResize);
                     absorbEvent = true;
                     break;
 
                 case resizing:
-                    // NSLog(@"resizing -> idle");
-                    stop(moveResize);
+                    // NSLog(@"idle -> moving/resizing");
+                    startTracking(event, moveResize);
+                    determineResizeDirection(event, moveResize);
+                    absorbEvent = true;
                     break;
 
                 default:
@@ -287,12 +289,12 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
                 case idle:
                     // NSLog(@"moving -> idle");
-                    stop(moveResize);
+                    stopTracking(moveResize);
                     break;
 
                 case resizing:
                     // NSLog(@"moving -> resizing");
-                    absorbEvent = startResizing(event, moveResize);
+                    absorbEvent = determineResizeDirection(event, moveResize);
                     break;
 
                 default:
@@ -311,12 +313,12 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
                 case idle:
                     // NSLog(@"resizing -> idle");
-                    stop(moveResize);
+                    stopTracking(moveResize);
                     break;
 
                 case moving:
                     // NSLog(@"resizing -> moving");
-                    startMoving(event, moveResize);
+                    startTracking(event, moveResize);
                     absorbEvent = true;
                     break;
 

--- a/easy-move-resize/EMRAppDelegate.m
+++ b/easy-move-resize/EMRAppDelegate.m
@@ -1,6 +1,7 @@
 #import "EMRAppDelegate.h"
 #import "EMRMoveResize.h"
 #import "EMRPreferences.h"
+#import "EMRHelper.h"
 
 typedef enum : NSUInteger {
     idle = 0,
@@ -236,9 +237,13 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     }
 
     if (moveModifiersDown && resizeModifiersDown) {
-        // default to resize as the wider set
-        // TODO: check which one is wider
-        moveModifiersDown = false;
+        // if one mask is the super set of the other we want to disable the narrower mask
+        // otherwise it may steal the event from the other mode
+        if (compareMasks(moveKeyModifierFlags, resizeKeyModifierFlags) == wider) {
+            resizeModifiersDown = false;
+        } else if (compareMasks(moveKeyModifierFlags, resizeKeyModifierFlags) == smaller) {
+            moveModifiersDown = false;
+        }
     }
 
     if (! (moveModifiersDown || resizeModifiersDown) && state == idle) {

--- a/easy-move-resize/EMRHelper.h
+++ b/easy-move-resize/EMRHelper.h
@@ -1,0 +1,26 @@
+//
+//  EMRHelper.h
+//  easy-move-resize
+//
+//  Created by Sven A. Schmidt on 10/06/2018.
+//  Copyright © 2018 Daniel Marcotte. All rights reserved.
+//
+
+#ifndef EMRHelper_h
+#define EMRHelper_h
+
+#import <Foundation/Foundation.h>
+
+
+typedef enum : NSUInteger {
+    equal,
+    wider,
+    smaller,
+    disjoint
+} MaskComparison;
+
+
+MaskComparison compareMasks(int mask1, int mask2);
+
+
+#endif /* EMRHelper_h */

--- a/easy-move-resize/EMRHelper.m
+++ b/easy-move-resize/EMRHelper.m
@@ -1,0 +1,28 @@
+//
+//  EMRHelper.m
+//  easy-move-resize
+//
+//  Created by Sven A. Schmidt on 10/06/2018.
+//  Copyright © 2018 Daniel Marcotte. All rights reserved.
+//
+
+#import "EMRHelper.h"
+
+
+MaskComparison compareMasks(int mask1, int mask2) {
+    if (mask1 == mask2) {
+        return equal;
+    } else {
+        int xor = mask1 ^ mask2;
+        if (xor & mask1) {
+            if (xor & mask2) {
+                return disjoint;
+            } else {
+                return wider;
+            }
+        } else {
+            return smaller;
+        }
+    }
+}
+

--- a/easy-move-resize/EMRMoveResize.h
+++ b/easy-move-resize/EMRMoveResize.h
@@ -36,5 +36,6 @@ struct ResizeSection {
 @property CFTimeInterval tracking;
 @property NSPoint wndPosition;
 @property NSSize wndSize;
+@property bool alwaysResizeBottomRight;
 
 @end

--- a/easy-move-resize/EMRMoveResize.m
+++ b/easy-move-resize/EMRMoveResize.m
@@ -6,6 +6,7 @@
 @synthesize tracking = _tracking;
 @synthesize wndPosition = _wndPosition;
 @synthesize wndSize = _wndSize;
+@synthesize alwaysResizeBottomRight = _alwaysResizeBottomRight;
 
 + (EMRMoveResize*)instance {
     static EMRMoveResize *instance = nil;

--- a/easy-move-resize/EMRPreferences.h
+++ b/easy-move-resize/EMRPreferences.h
@@ -14,6 +14,7 @@
 #define CAPS_KEY @"CAPS" // CAPS lock
 #define ALT_KEY @"ALT" // Alternate or Option key
 #define CMD_KEY @"CMD"
+#define FN_KEY @"FN"
 
 @interface EMRPreferences : NSObject {
     

--- a/easy-move-resize/EMRPreferences.h
+++ b/easy-move-resize/EMRPreferences.h
@@ -8,13 +8,29 @@
 #ifndef EMRPreferences_h
 #define EMRPreferences_h
 
-#define MODIFIER_FLAGS_DEFAULTS_KEY @"ModifierFlags"
+#define MODIFIER_CLICK_FLAGS_DEFAULTS_KEY @"ModifierFlags"
+#define MODIFIER_HOVER_MOVE_FLAGS_DEFAULTS_KEY @"HoverMoveModifierFlags"
+#define MODIFIER_HOVER_RESIZE_FLAGS_DEFAULTS_KEY @"HoverResizeModifierFlags"
+#define EMR_MODE_DEFAULTS_KEY @"EMRMode"
 #define CTRL_KEY @"CTRL"
 #define SHIFT_KEY @"SHIFT"
 #define CAPS_KEY @"CAPS" // CAPS lock
 #define ALT_KEY @"ALT" // Alternate or Option key
 #define CMD_KEY @"CMD"
 #define FN_KEY @"FN"
+
+
+typedef enum : NSUInteger {
+    clickMode,
+    hoverMode
+} EMRMode;
+
+
+typedef enum : NSUInteger {
+    clickFlags,
+    hoverMoveFlags,
+    hoverResizeFlags,
+} FlagSet;
 
 @interface EMRPreferences : NSObject {
     
@@ -23,14 +39,20 @@
 // Initialize an EMRPreferences, persisting settings to the given userDefaults
 - (id)initWithUserDefaults:(NSUserDefaults *)defaults;
 
-// Get the modifier flags from the standard preferences
-- (int) modifierFlags;
+// Get the modifier flags from the standard preferences for a given set
+- (int)modifierFlagsForFlagSet:(FlagSet)flagSet;
 
 // Set or unset the given modifier key in the preferences
-- (void) setModifierKey:(NSString*)singleFlagString enabled:(BOOL)enabled;
+- (void) setModifierKey:(NSString*)singleFlagString enabled:(BOOL)enabled flagSet:(FlagSet)flagSet;
 
 // returns a set of the currently persisted key constants
-- (NSSet*) getFlagStringSet;
+- (NSSet*) getFlagStringSetForFlagSet:(FlagSet)flagSet;
+
+// returns EMR mode - click or hover
+- (EMRMode)mode;
+
+// set EMR mode
+- (void)setMode:(EMRMode)mode;
 
 // reset preferences to the defaults
 - (void)setToDefaults;

--- a/easy-move-resize/EMRPreferences.m
+++ b/easy-move-resize/EMRPreferences.m
@@ -109,7 +109,10 @@
     if ([flagList containsObject:CMD_KEY]) {
         modifierFlags |= kCGEventFlagMaskCommand;
     }
-    
+    if ([flagList containsObject:FN_KEY]) {
+        modifierFlags |= kCGEventFlagMaskSecondaryFn;
+    }
+
     return modifierFlags;
 }
 @end

--- a/easy-move-resize/EMRPreferences.m
+++ b/easy-move-resize/EMRPreferences.m
@@ -1,6 +1,7 @@
 #import "EMRPreferences.h"
 
-#define DEFAULT_MODIFIER_FLAGS kCGEventFlagMaskCommand | kCGEventFlagMaskControl
+#define DEFAULT_CLICK_MODIFIER_FLAGS kCGEventFlagMaskCommand | kCGEventFlagMaskControl
+
 
 @implementation EMRPreferences {
 @private
@@ -18,64 +19,141 @@
     self = [super init];
     if (self) {
         userDefaults = defaults;
-        NSString *modifierFlagString = [userDefaults stringForKey:MODIFIER_FLAGS_DEFAULTS_KEY];
-        if (modifierFlagString == nil) {
-            // ensure our defaults are initialized
-            [self setToDefaults];
+        for (NSString *key in @[MODIFIER_CLICK_FLAGS_DEFAULTS_KEY, MODIFIER_HOVER_MOVE_FLAGS_DEFAULTS_KEY, MODIFIER_HOVER_RESIZE_FLAGS_DEFAULTS_KEY]) {
+            NSString *modifierFlagString = [userDefaults stringForKey:key];
+            if (modifierFlagString == nil) {
+                // ensure our defaults are initialized
+                [self setToDefaultsForKey:key];
+            }
         }
     }
     return self;
 }
 
-- (int)modifierFlags {
-    int modifierFlags = 0;
-    
-    NSString *modifierFlagString = [userDefaults stringForKey:MODIFIER_FLAGS_DEFAULTS_KEY];
-    if (modifierFlagString == nil) {
-        return DEFAULT_MODIFIER_FLAGS;
+- (NSString *)keyForFlagSet:(FlagSet)flagSet {
+    switch (flagSet) {
+        case clickFlags:
+            return MODIFIER_CLICK_FLAGS_DEFAULTS_KEY;
+            break;
+
+        case hoverMoveFlags:
+            return MODIFIER_HOVER_MOVE_FLAGS_DEFAULTS_KEY;
+            break;
+
+        case hoverResizeFlags:
+            return MODIFIER_HOVER_RESIZE_FLAGS_DEFAULTS_KEY;
+            break;
+
+        default:
+            // must not reach this
+            assert(false);
+            break;
     }
-    
+}
+
+- (NSArray *)modifierDefaultsForKey:(NSString *)key {
+    NSDictionary* modifierDefaults = @{
+                                       MODIFIER_CLICK_FLAGS_DEFAULTS_KEY: @[CTRL_KEY, CMD_KEY],
+                                       MODIFIER_HOVER_MOVE_FLAGS_DEFAULTS_KEY: @[CTRL_KEY, ALT_KEY],
+                                       MODIFIER_HOVER_RESIZE_FLAGS_DEFAULTS_KEY: @[CTRL_KEY, ALT_KEY, CMD_KEY]
+                                       };
+    return modifierDefaults[key];
+}
+
+- (NSString *)flagStringForFlags:(NSArray *)flags {
+    return [flags componentsJoinedByString:@","];
+}
+
+- (int)modifierFlagsForFlagSet:(FlagSet)flagSet {
+    NSString *key = [self keyForFlagSet:flagSet];
+    int modifierFlags = 0;
+
+    NSString *modifierFlagString = [userDefaults stringForKey:key];
+    if (modifierFlagString == nil) {
+        NSArray *defaults = [self modifierDefaultsForKey:key];
+        modifierFlagString = [self flagStringForFlags:defaults];
+    }
+
     modifierFlags = [self flagsFromFlagString:modifierFlagString];
-    
+
     return modifierFlags;
 }
 
-- (void)setModifierFlagString:(NSString *)flagString {
+- (void)setModifierFlagString:(NSString *)flagString forKey:(NSString *)key {
     flagString = [[flagString stringByReplacingOccurrencesOfString:@" " withString:@""] uppercaseString];
-    [userDefaults setObject:flagString forKey:MODIFIER_FLAGS_DEFAULTS_KEY];
+    [userDefaults setObject:flagString forKey:key];
 }
 
 
-- (void)setModifierKey:(NSString *)singleFlagString enabled:(BOOL)enabled {
+- (void) setModifierKey:(NSString*)singleFlagString enabled:(BOOL)enabled flagSet:(FlagSet)flagSet {
     singleFlagString = [singleFlagString uppercaseString];
-    NSString *modifierFlagString = [userDefaults stringForKey:MODIFIER_FLAGS_DEFAULTS_KEY];
+    NSString *key = [self keyForFlagSet:flagSet];
+    NSString *modifierFlagString = [userDefaults stringForKey:key];
     if (modifierFlagString == nil) {
         NSLog(@"Unexpected null... this should always have a value");
-        [self setToDefaults];
+        [self setToDefaultsForKey:key];
     }
-    NSMutableSet *flagSet = [self createSetFromFlagString:modifierFlagString];
+    NSMutableSet *flags = [self createSetFromFlagString:modifierFlagString];
     if (enabled) {
-        [flagSet addObject:singleFlagString];
+        [flags addObject:singleFlagString];
     }
     else {
-        [flagSet removeObject:singleFlagString];
+        [flags removeObject:singleFlagString];
     }
-    [self setModifierFlagString:[[flagSet allObjects] componentsJoinedByString:@","]];
+    [self setModifierFlagString:[[flags allObjects] componentsJoinedByString:@","] forKey:key];
 }
 
-- (NSSet*)getFlagStringSet {
-    NSString *modifierFlagString = [userDefaults stringForKey:MODIFIER_FLAGS_DEFAULTS_KEY];
+
+- (NSSet*)getFlagStringSetForFlagSet:(FlagSet)flagSet {
+    NSString *key = [self keyForFlagSet:flagSet];
+    NSString *modifierFlagString = [userDefaults stringForKey:key];
     if (modifierFlagString == nil) {
         NSLog(@"Unexpected null... this should always have a value");
-        [self setToDefaults];
+        [self setToDefaultsForKey:key];
     }
-    NSMutableSet *flagSet = [self createSetFromFlagString:modifierFlagString];
-    return flagSet;
+    NSMutableSet *flags = [self createSetFromFlagString:modifierFlagString];
+    return flags;
 }
 
-- (void)setToDefaults {
-    [self setModifierFlagString:[@[CTRL_KEY, CMD_KEY] componentsJoinedByString:@","]];
+
+- (EMRMode)defaultMode {
+    return clickMode;
 }
+
+
+// returns EMR mode - click or hover
+- (EMRMode)mode {
+    NSNumber *mode = [userDefaults objectForKey:EMR_MODE_DEFAULTS_KEY];
+    if (mode == nil) {
+        return [self defaultMode];
+    } else {
+        return mode.integerValue;
+    }
+}
+
+
+// set EMR mode
+- (void)setMode:(EMRMode)mode {
+    [userDefaults setInteger:mode forKey:EMR_MODE_DEFAULTS_KEY];
+}
+
+
+- (void)setToDefaultsForKey:(NSString *)key {
+    NSArray *flags = [self modifierDefaultsForKey:key];
+    NSString *flagString = [self flagStringForFlags:flags];
+    [self setModifierFlagString:flagString forKey:key];
+}
+
+
+- (void)setToDefaults {
+    for (NSString *key in @[MODIFIER_CLICK_FLAGS_DEFAULTS_KEY, MODIFIER_HOVER_MOVE_FLAGS_DEFAULTS_KEY, MODIFIER_HOVER_RESIZE_FLAGS_DEFAULTS_KEY]) {
+        NSArray *flags = [self modifierDefaultsForKey:key];
+        NSString *flagString = [self flagStringForFlags:flags];
+        [self setModifierFlagString:flagString forKey:key];
+    }
+    [self setMode:[self defaultMode]];
+}
+
 
 - (NSMutableSet*)createSetFromFlagString:(NSString*)modifierFlagString {
     modifierFlagString = [[modifierFlagString stringByReplacingOccurrencesOfString:@" " withString:@""] uppercaseString];

--- a/easy-move-resize/EMRPreferencesController.h
+++ b/easy-move-resize/EMRPreferencesController.h
@@ -1,0 +1,50 @@
+//
+//  EMRPreferencesController.h
+//  easy-move-resize
+//
+//  Created by Sven A. Schmidt on 13/06/2018.
+//  Copyright © 2018 Daniel Marcotte. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+#import "EMRPreferences.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EMRPreferencesController : NSWindowController {
+    EMRPreferences *_prefs;
+}
+
+@property EMRPreferences *prefs;
+
+@property (weak) IBOutlet NSButton *altClickButton;
+@property (weak) IBOutlet NSButton *commandClickButton;
+@property (weak) IBOutlet NSButton *controlClickButton;
+@property (weak) IBOutlet NSButton *fnClickButton;
+@property (weak) IBOutlet NSButton *shiftClickButton;
+
+@property (weak) IBOutlet NSButton *altHoverMoveButton;
+@property (weak) IBOutlet NSButton *commandHoverMoveButton;
+@property (weak) IBOutlet NSButton *controlHoverMoveButton;
+@property (weak) IBOutlet NSButton *fnHoverMoveButton;
+@property (weak) IBOutlet NSButton *shiftHoverMoveButton;
+
+@property (weak) IBOutlet NSButton *altHoverResizeButton;
+@property (weak) IBOutlet NSButton *commandHoverResizeButton;
+@property (weak) IBOutlet NSButton *controlHoverResizeButton;
+@property (weak) IBOutlet NSButton *fnHoverResizeButton;
+@property (weak) IBOutlet NSButton *shiftHoverResizeButton;
+
+
+@property (weak) IBOutlet NSButton *clickModeButton;
+@property (weak) IBOutlet NSButton *hoverModeButton;
+
+- (IBAction)modifierClicked:(NSButton *)sender;
+
+- (IBAction)clickModeClicked:(id)sender;
+- (IBAction)hoverModeClicked:(id)sender;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/easy-move-resize/EMRPreferencesController.m
+++ b/easy-move-resize/EMRPreferencesController.m
@@ -1,0 +1,105 @@
+//
+//  EMRPreferencesController.m
+//  easy-move-resize
+//
+//  Created by Sven A. Schmidt on 13/06/2018.
+//  Copyright © 2018 Daniel Marcotte. All rights reserved.
+//
+
+#import "EMRPreferencesController.h"
+
+@interface EMRPreferencesController ()
+
+@end
+
+@implementation EMRPreferencesController
+
+- (void)windowDidLoad {
+    [super windowDidLoad];
+    
+    if (_prefs) {
+        {
+            EMRMode mode = _prefs.mode;
+            _clickModeButton.state = (mode == clickMode) ? NSOnState: NSOffState;
+            _hoverModeButton.state = (mode == hoverMode) ? NSOnState: NSOffState;
+        }
+
+        {
+            NSSet* flags = [_prefs getFlagStringSetForFlagSet:clickFlags];
+            NSDictionary *keyButtonMap = @{
+                                           ALT_KEY: _altClickButton,
+                                           CMD_KEY: _commandClickButton,
+                                           CTRL_KEY: _controlClickButton,
+                                           FN_KEY: _fnClickButton,
+                                           SHIFT_KEY: _shiftClickButton
+                                  };
+            for (NSString *key in keyButtonMap) {
+                NSButton *button = keyButtonMap[key];
+                button.state = [flags containsObject:key] ? NSOnState : NSOffState;
+            }
+        }
+
+        {
+            NSSet* flags = [_prefs getFlagStringSetForFlagSet:hoverMoveFlags];
+            NSDictionary *keyButtonMap = @{
+                                           ALT_KEY: _altHoverMoveButton,
+                                           CMD_KEY: _commandHoverMoveButton,
+                                           CTRL_KEY: _controlHoverMoveButton,
+                                           FN_KEY: _fnHoverMoveButton,
+                                           SHIFT_KEY: _shiftHoverMoveButton
+                                           };
+            for (NSString *key in keyButtonMap) {
+                NSButton *button = keyButtonMap[key];
+                button.state = [flags containsObject:key] ? NSOnState : NSOffState;
+            }
+        }
+
+        {
+            NSSet* flags = [_prefs getFlagStringSetForFlagSet:hoverResizeFlags];
+            NSDictionary *keyButtonMap = @{
+                                           ALT_KEY: _altHoverResizeButton,
+                                           CMD_KEY: _commandHoverResizeButton,
+                                           CTRL_KEY: _controlHoverResizeButton,
+                                           FN_KEY: _fnHoverResizeButton,
+                                           SHIFT_KEY: _shiftHoverResizeButton
+                                           };
+            for (NSString *key in keyButtonMap) {
+                NSButton *button = keyButtonMap[key];
+                button.state = [flags containsObject:key] ? NSOnState : NSOffState;
+            }
+        }
+
+    }
+}
+
+- (IBAction)modifierClicked:(NSButton *)sender {
+    bool enabled = sender.state == NSOnState;
+
+    NSSet *clickControls = [NSSet setWithObjects:_altClickButton, _commandClickButton, _controlClickButton, _fnClickButton, _shiftClickButton, nil];
+    NSSet *hoverMoveControls = [NSSet setWithObjects:_altHoverMoveButton, _commandHoverMoveButton, _controlHoverMoveButton, _fnHoverMoveButton, _shiftHoverMoveButton, nil];
+    NSSet *hoverResizeControls = [NSSet setWithObjects:_altHoverResizeButton, _commandHoverResizeButton, _controlHoverResizeButton, _fnHoverResizeButton, _shiftHoverResizeButton, nil];
+
+    if ([clickControls containsObject:sender]) {
+        [_prefs setModifierKey:sender.title enabled:enabled flagSet:clickFlags];
+    } else if ([hoverMoveControls containsObject:sender]) {
+        [_prefs setModifierKey:sender.title enabled:enabled flagSet:hoverMoveFlags];
+    } else if ([hoverResizeControls containsObject:sender]) {
+        [_prefs setModifierKey:sender.title enabled:enabled flagSet:hoverResizeFlags];
+    }
+}
+
+- (IBAction)clickModeClicked:(id)sender {
+    if (_clickModeButton.state == NSOnState) {
+        _hoverModeButton.state = NSOffState;
+        [_prefs setMode:clickMode];
+    }
+}
+
+- (IBAction)hoverModeClicked:(id)sender {
+    if (_hoverModeButton.state == NSOnState) {
+        _clickModeButton.state = NSOffState;
+        [_prefs setMode:hoverMode];
+    }
+}
+
+@end

--- a/easy-move-resize/EMRPreferencesController.xib
+++ b/easy-move-resize/EMRPreferencesController.xib
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
+        <capability name="box content view" minToolsVersion="7.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="EMRPreferencesController">
+            <connections>
+                <outlet property="altClickButton" destination="FcM-NA-7cC" id="Ndt-lf-5c7"/>
+                <outlet property="altHoverMoveButton" destination="Sj9-Rc-bDN" id="eVv-G2-wrH"/>
+                <outlet property="altHoverResizeButton" destination="frh-8a-H0z" id="Fnb-mx-fD2"/>
+                <outlet property="clickModeButton" destination="gqw-BY-sZk" id="BO7-Ye-I8r"/>
+                <outlet property="commandClickButton" destination="czb-Ol-s2L" id="qew-vw-lOp"/>
+                <outlet property="commandHoverMoveButton" destination="ihP-uA-QNF" id="7Fw-g1-Nws"/>
+                <outlet property="commandHoverResizeButton" destination="IHA-Hv-cF2" id="d2O-xb-JzB"/>
+                <outlet property="controlClickButton" destination="FS7-FE-wuk" id="7bt-Au-gr8"/>
+                <outlet property="controlHoverMoveButton" destination="f0u-93-rmH" id="VaT-d7-ckP"/>
+                <outlet property="controlHoverResizeButton" destination="Vho-Wo-heQ" id="944-zB-rRg"/>
+                <outlet property="fnClickButton" destination="waA-tt-wsa" id="CuZ-dD-5uu"/>
+                <outlet property="fnHoverMoveButton" destination="RzX-et-TGM" id="96d-iQ-LTh"/>
+                <outlet property="fnHoverResizeButton" destination="ZoB-Ah-hDB" id="sRf-XB-Zj9"/>
+                <outlet property="hoverModeButton" destination="bTi-3J-FVd" id="il5-FY-FCn"/>
+                <outlet property="shiftClickButton" destination="Umr-4M-fJ5" id="zzc-i5-HcB"/>
+                <outlet property="shiftHoverMoveButton" destination="cBr-VD-5GB" id="V84-0c-rPe"/>
+                <outlet property="shiftHoverResizeButton" destination="t0H-b4-ute" id="KNa-cC-CXw"/>
+                <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="EMRPreferencesWindow" animationBehavior="default" id="F0z-JX-Cv5">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="196" y="240" width="503" height="477"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
+            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="503" height="477"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gqw-BY-sZk">
+                        <rect key="frame" x="36" y="440" width="132" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="radio" title="Mouse click mode" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1DG-Ke-H5d">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="clickModeClicked:" target="-2" id="Lcg-QE-xAv"/>
+                        </connections>
+                    </button>
+                    <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="TxY-jI-ujR">
+                        <rect key="frame" x="12" y="243" width="479" height="5"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    </box>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bTi-3J-FVd">
+                        <rect key="frame" x="36" y="203" width="96" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="radio" title="Hover mode" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="kzA-Zs-qXO">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="hoverModeClicked:" target="-2" id="ad6-vO-afa"/>
+                        </connections>
+                    </button>
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="147" translatesAutoresizingMaskIntoConstraints="NO" id="GeX-Qx-8dF">
+                        <rect key="frame" x="301" y="66" width="151" height="154"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="iR5-Jr-TWa">
+                            <font key="font" metaFont="smallSystem"/>
+                            <string key="title">In ‘hover mode‘, simply holding down the given modifier keys will allow moving or resizing windows.
+
+Resizing will act on the lower right corner of the window</string>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="147" translatesAutoresizingMaskIntoConstraints="NO" id="uLx-ab-t6M">
+                        <rect key="frame" x="300" y="289" width="151" height="168"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="iaS-2d-jGP">
+                            <font key="font" metaFont="smallSystem"/>
+                            <string key="title">In ‘mouse click mode’, windows are moved by clicking the left mouse button and holding the defined keyboard modifiers.
+
+To resize windows press the keyboard modifiers and click and drag the right mouse button. Resizing will act on the nearest window corner.</string>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <box autoresizesSubviews="NO" fixedFrame="YES" borderType="line" title="Move" translatesAutoresizingMaskIntoConstraints="NO" id="7aw-kd-4Fq">
+                        <rect key="frame" x="52" y="23" width="93" height="151"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <view key="contentView" id="Xtr-41-rxU">
+                            <rect key="frame" x="3" y="3" width="87" height="133"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ihP-uA-QNF">
+                                    <rect key="frame" x="18" y="77" width="51" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Cmd" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="3PP-dE-lfe">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="PAQ-OB-11D"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RzX-et-TGM">
+                                    <rect key="frame" x="18" y="37" width="37" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Fn" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="42d-0p-cJT">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="aMK-0s-0PO"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cBr-VD-5GB">
+                                    <rect key="frame" x="18" y="18" width="51" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Shift" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="PB9-7z-eGH">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="U2s-6f-0PA"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f0u-93-rmH">
+                                    <rect key="frame" x="18" y="57" width="44" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Ctrl" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="F2V-Bc-F25">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="Fgd-sn-TvK"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sj9-Rc-bDN">
+                                    <rect key="frame" x="18" y="97" width="39" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Alt" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="b9h-4w-WRY">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="qob-fA-8Pz"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </view>
+                    </box>
+                    <box autoresizesSubviews="NO" fixedFrame="YES" borderType="line" title="Resize" translatesAutoresizingMaskIntoConstraints="NO" id="fRg-Ig-lQz">
+                        <rect key="frame" x="161" y="23" width="93" height="151"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <view key="contentView" id="PNo-mj-ccR">
+                            <rect key="frame" x="3" y="3" width="87" height="133"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IHA-Hv-cF2">
+                                    <rect key="frame" x="18" y="77" width="51" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Cmd" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rhh-5v-WPT">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="g04-U6-ijT"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="frh-8a-H0z">
+                                    <rect key="frame" x="18" y="97" width="39" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Alt" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vUk-b7-GDi">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="u48-PV-uwQ"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Vho-Wo-heQ">
+                                    <rect key="frame" x="18" y="57" width="44" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Ctrl" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="55x-gW-pVv">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="mfe-gl-dqc"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="t0H-b4-ute">
+                                    <rect key="frame" x="18" y="18" width="51" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Shift" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="gDJ-8i-tJ0">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="DK8-EA-Rjc"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZoB-Ah-hDB">
+                                    <rect key="frame" x="18" y="37" width="37" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Fn" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="bmZ-dh-lML">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="pAx-l1-Rm3"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </view>
+                    </box>
+                    <box autoresizesSubviews="NO" fixedFrame="YES" borderType="line" title="Modifiers" translatesAutoresizingMaskIntoConstraints="NO" id="2Wx-fS-JVJ">
+                        <rect key="frame" x="52" y="262" width="93" height="151"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <view key="contentView" id="4JH-79-euL">
+                            <rect key="frame" x="3" y="3" width="87" height="133"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="czb-Ol-s2L">
+                                    <rect key="frame" x="18" y="77" width="51" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Cmd" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Hkf-4x-y0K">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="Swo-pZ-YDT"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="waA-tt-wsa">
+                                    <rect key="frame" x="18" y="37" width="37" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Fn" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="jbh-Mb-fJJ">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="p1O-Kz-Uva"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Umr-4M-fJ5">
+                                    <rect key="frame" x="18" y="18" width="51" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Shift" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="9G5-j8-uQp">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="VgW-R8-edr"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FS7-FE-wuk">
+                                    <rect key="frame" x="18" y="57" width="44" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Ctrl" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="IVV-T7-t8h">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="Uj0-kX-wwY"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FcM-NA-7cC">
+                                    <rect key="frame" x="18" y="97" width="39" height="18"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="check" title="Alt" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Rrh-FJ-qDV">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="modifierClicked:" target="-2" id="xbE-In-pGg"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </view>
+                    </box>
+                </subviews>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+            </connections>
+            <point key="canvasLocation" x="-111.5" y="-54.5"/>
+        </window>
+    </objects>
+</document>

--- a/easy-move-resize/en.lproj/MainMenu.xib
+++ b/easy-move-resize/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1509" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14269.12" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14269.12"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -677,6 +677,12 @@
                         <action selector="modifierToggle:" target="494" id="niS-3l-sN2"/>
                     </connections>
                 </menuItem>
+                <menuItem title="Fn" id="yTr-4R-8Jm">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="modifierToggle:" target="494" id="qB1-v2-3aI"/>
+                    </connections>
+                </menuItem>
                 <menuItem title="Shift" id="SZL-bI-dng">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
@@ -706,6 +712,7 @@
                 <outlet property="cmdMenu" destination="yMO-nW-fjN" id="TRT-4a-jj5"/>
                 <outlet property="ctrlMenu" destination="cOd-3Z-1Py" id="mtX-4X-qya"/>
                 <outlet property="disabledMenu" destination="Q0w-G0-Ppy" id="D3v-HP-HjG"/>
+                <outlet property="fnMenu" destination="yTr-4R-8Jm" id="rZv-AR-2eF"/>
                 <outlet property="shiftMenu" destination="SZL-bI-dng" id="YZk-pM-c3k"/>
                 <outlet property="statusMenu" destination="obP-gH-pam" id="YfI-Jt-Lpf"/>
             </connections>

--- a/easy-move-resize/en.lproj/MainMenu.xib
+++ b/easy-move-resize/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14269.12" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14269.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -659,41 +659,10 @@
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="a5T-MQ-31B"/>
-                <menuItem title="Alt" id="toO-ef-6Sa">
+                <menuItem title="Preferences..." id="XfF-1V-Bsx">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
-                        <action selector="modifierToggle:" target="494" id="gvG-0m-DpJ"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Cmd" id="yMO-nW-fjN">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="modifierToggle:" target="494" id="HrM-v0-sYh"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Ctrl" id="cOd-3Z-1Py">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="modifierToggle:" target="494" id="niS-3l-sN2"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Fn" id="yTr-4R-8Jm">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="modifierToggle:" target="494" id="qB1-v2-3aI"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Shift" id="SZL-bI-dng">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="modifierToggle:" target="494" id="tw0-HJ-yQk"/>
-                    </connections>
-                </menuItem>
-                <menuItem isSeparatorItem="YES" id="CnB-BD-kwb"/>
-                <menuItem title="Reset to Defaults" id="emi-it-fz4">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="resetModifiersToDefaults:" target="494" id="6fR-bD-2t5"/>
+                        <action selector="showPreferences:" target="494" id="mfm-f2-Mgw"/>
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="16Z-ZA-yWP"/>
@@ -708,12 +677,7 @@
         </menu>
         <customObject id="494" customClass="EMRAppDelegate">
             <connections>
-                <outlet property="altMenu" destination="toO-ef-6Sa" id="nQz-2m-M8b"/>
-                <outlet property="cmdMenu" destination="yMO-nW-fjN" id="TRT-4a-jj5"/>
-                <outlet property="ctrlMenu" destination="cOd-3Z-1Py" id="mtX-4X-qya"/>
                 <outlet property="disabledMenu" destination="Q0w-G0-Ppy" id="D3v-HP-HjG"/>
-                <outlet property="fnMenu" destination="yTr-4R-8Jm" id="rZv-AR-2eF"/>
-                <outlet property="shiftMenu" destination="SZL-bI-dng" id="YZk-pM-c3k"/>
                 <outlet property="statusMenu" destination="obP-gH-pam" id="YfI-Jt-Lpf"/>
             </connections>
         </customObject>

--- a/easy-move-resizeTests/EMRHelperTest.m
+++ b/easy-move-resizeTests/EMRHelperTest.m
@@ -1,0 +1,37 @@
+//
+//  EMRHelperTest.m
+//  easy-move-resizeTests
+//
+//  Created by Sven A. Schmidt on 10/06/2018.
+//  Copyright © 2018 Daniel Marcotte. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "EMRHelper.h"
+
+@interface EMRHelperTest : XCTestCase
+
+@end
+
+
+@implementation EMRHelperTest
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testCompareMasks {
+    int widerMask = kCGEventFlagMaskShift | kCGEventFlagMaskCommand;
+    int smallerMask = kCGEventFlagMaskCommand;
+    int disjointMask = kCGEventFlagMaskControl | kCGEventFlagMaskSecondaryFn;
+    XCTAssertEqual(compareMasks(widerMask, smallerMask), wider);
+    XCTAssertEqual(compareMasks(smallerMask, widerMask), smaller);
+    XCTAssertEqual(compareMasks(widerMask, widerMask), equal);
+    XCTAssertEqual(compareMasks(widerMask, disjointMask), disjoint);
+}
+
+@end

--- a/easy-move-resizeTests/EMRPreferencesTest.m
+++ b/easy-move-resizeTests/EMRPreferencesTest.m
@@ -25,17 +25,17 @@
 
 - (void)testResetPreferences {
     [preferences setToDefaults];
-    NSSet *flagStringSet = [preferences getFlagStringSet];
+    NSSet *flagStringSet = [preferences getFlagStringSetForFlagSet:clickFlags];
     NSSet *expectedSet = [NSSet setWithArray:@[@"CTRL", @"CMD"]];
     XCTAssertEqualObjects(flagStringSet, expectedSet, "Should contain the expected defaults");
 
-    [preferences setModifierKey:@"CTRL" enabled:NO];
-    flagStringSet = [preferences getFlagStringSet];
+    [preferences setModifierKey:@"CTRL" enabled:NO flagSet:clickFlags];
+    flagStringSet = [preferences getFlagStringSetForFlagSet:clickFlags];
     expectedSet = [NSSet setWithArray:@[@"CMD"]];
     XCTAssertEqualObjects(flagStringSet, expectedSet, "Should contain the modified defaults");
 
     [preferences setToDefaults];
-    flagStringSet = [preferences getFlagStringSet];
+    flagStringSet = [preferences getFlagStringSetForFlagSet:clickFlags];
     expectedSet = [NSSet setWithArray:@[@"CMD", @"CTRL"]];
     XCTAssertEqualObjects(flagStringSet, expectedSet, "Should contain the restored defaults");
 }


### PR DESCRIPTION
I've been using Better Touch Tool for ages to provide a similar x windows inspired move and resize behaviour to your EMR project. When BTT broke in macOS Mojave I looked for a replacement and found EMR.

One big difference in how I used BTT was that I had mapped different key modifiers for move and resize and solely required those. This allows me to move and resize without pressing any mouse keys - which is great for track pad use and to avoid bringing the window into the foreground.

Now it was easy to hack EMR into supporting my mode (calling it "hover mode" for lack of a better term) and I spent a bit of time setting up a preferences window for it. Since it requires two sets of modifiers instead of just one, the menu based system was a bit awkward.

Here's what this looks like:

<img width="593" alt="screen shot 2018-06-17 at 12 40 02" src="https://user-images.githubusercontent.com/65520/41507085-9a3dda2a-722b-11e8-9cd3-00cff48672e9.png">

I also spent quite a bit of time trying to support both the existing "click mode" as well as my new "hover mode" but it turns out that I've currently simply broken "click mode" despite my attempts to keep it functional 😞

I feel like it shouldn't be too hard to re-instate it and I'll try to spend some more time on it.

In the interim I wanted to open up this PR to see what your thoughts are.

The changes are quite sweeping - apologies for that as well. It started out small and then it kinda got out of control 😅