### PR TITLE
Fix grabbing events from other user.

### DIFF
--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -26,5 +26,6 @@ static const double kResizeFilterInterval = 0.04;
 @property (weak) IBOutlet NSMenuItem *disabledMenu;
 @property (weak) IBOutlet NSMenuItem *bringWindowFrontMenu;
 @property (weak) IBOutlet NSMenuItem *middleClickResizeMenu;
+@property (nonatomic) BOOL sessionActive;
 
 @end

--- a/easy-move-resize/EMRAppDelegate.m
+++ b/easy-move-resize/EMRAppDelegate.m
@@ -24,6 +24,10 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     CGEventType resizeModifierDragged = kCGEventRightMouseDragged;
     CGEventType resizeModifierUp = kCGEventRightMouseUp;
 
+    if (![ourDelegate sessionActive]) {
+        return event;
+    }
+
     if (keyModifierFlags == 0) {
         // No modifier keys set. Disable behaviour.
         return event;
@@ -300,6 +304,27 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     [moveResize setRunLoopSource:runLoopSource];
     [self enableRunLoopSource:moveResize];
     CFRelease(runLoopSource);
+
+    _sessionActive = true;
+    [[[NSWorkspace sharedWorkspace] notificationCenter]
+            addObserver:self
+            selector:@selector(becameActive:)
+            name:NSWorkspaceSessionDidBecomeActiveNotification
+            object:nil];
+
+    [[[NSWorkspace sharedWorkspace] notificationCenter]
+            addObserver:self
+            selector:@selector(becameInactive:)
+            name:NSWorkspaceSessionDidResignActiveNotification
+            object:nil];
+}
+
+- (void)becameActive:(NSNotification*) notification {
+    _sessionActive = true;
+}
+
+- (void)becameInactive:(NSNotification*) notification {
+    _sessionActive = false;
 }
 
 -(void)awakeFromNib{


### PR DESCRIPTION
When current session become inactive, CGEvent should no longer be
processed.