### PR TITLE
Add option to only use the resize function

### DIFF
--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -29,6 +29,7 @@ static const double kResizeFilterInterval = 0.04;
 @property (weak) IBOutlet NSMenuItem *disabledMenu;
 @property (weak) IBOutlet NSMenuItem *bringWindowFrontMenu;
 @property (weak) IBOutlet NSMenuItem *middleClickResizeMenu;
+@property (weak) IBOutlet NSMenuItem *resizeOnlyMenu;
 @property (weak) IBOutlet NSMenuItem *disabledAppsMenu;
 @property (weak) IBOutlet NSMenuItem *lastAppMenu;
 @property (nonatomic) BOOL sessionActive;

--- a/easy-move-resize/EMRAppDelegate.m
+++ b/easy-move-resize/EMRAppDelegate.m
@@ -20,6 +20,7 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     EMRAppDelegate *ourDelegate = (__bridge EMRAppDelegate*)refcon;
     int keyModifierFlags = [ourDelegate modifierFlags];
     bool shouldMiddleClickResize = [ourDelegate shouldMiddleClickResize];
+    bool resizeOnly = [ourDelegate resizeOnly];
     CGEventType resizeModifierDown = kCGEventRightMouseDown;
     CGEventType resizeModifierDragged = kCGEventRightMouseDragged;
     CGEventType resizeModifierUp = kCGEventRightMouseUp;
@@ -61,7 +62,7 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
         return event;
     }
 
-    if (type == kCGEventLeftMouseDown
+    if ((type == kCGEventLeftMouseDown && !resizeOnly)
             || type == resizeModifierDown) {
         CGPoint mouseLocation = CGEventGetLocation(event);
         [moveResize setTracking:CACurrentMediaTime()];
@@ -378,12 +379,16 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
     bool shouldBringWindowToFront = [preferences shouldBringWindowToFront];
     bool shouldMiddleClickResize = [preferences shouldMiddleClickResize];
+    bool resizeOnly = [preferences resizeOnly];
 
     if(shouldBringWindowToFront){
         [_bringWindowFrontMenu setState:1];
     }
     if(shouldMiddleClickResize){
         [_middleClickResizeMenu setState:1];
+    }
+    if(resizeOnly){
+        [_resizeOnlyMenu setState:1];
     }
     
     NSSet* flags = [preferences getFlagStringSet];
@@ -448,6 +453,13 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     }
 }
 
+- (IBAction)toggleResizeOnly:(id)sender {
+    NSMenuItem *menu = (NSMenuItem*)sender;
+    BOOL newState = ![menu state];
+    [menu setState:newState];
+    [preferences setResizeOnly:newState];
+}
+
 - (IBAction)disableLastApp:(id)sender {
     [preferences setDisabledForApp:[lastApp bundleIdentifier] withLocalizedName:[lastApp localizedName] disabled:YES];
     [_lastAppMenu setEnabled:FALSE];
@@ -479,6 +491,9 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 }
 -(BOOL)shouldMiddleClickResize {
     return [preferences shouldMiddleClickResize];
+}
+-(BOOL)resizeOnly {
+    return [preferences resizeOnly];
 }
 
 - (void)setMenusEnabled:(BOOL)enabled {

--- a/easy-move-resize/EMRPreferences.h
+++ b/easy-move-resize/EMRPreferences.h
@@ -10,6 +10,7 @@
 
 #define SHOULD_BRING_WINDOW_TO_FRONT @"BringToFront"
 #define SHOULD_MIDDLE_CLICK_RESIZE @"MiddleClickResize"
+#define RESIZE_ONLY @"ResizeOnly"
 #define MODIFIER_FLAGS_DEFAULTS_KEY @"ModifierFlags"
 #define DISABLED_APPS_DEFAULTS_KEY @"DisabledApps"
 #define CTRL_KEY @"CTRL"
@@ -24,6 +25,7 @@
 
 @property (nonatomic) BOOL shouldBringWindowToFront;
 @property (nonatomic) BOOL shouldMiddleClickResize;
+@property (nonatomic) BOOL resizeOnly;
 
 // Initialize an EMRPreferences, persisting settings to the given userDefaults
 - (id)initWithUserDefaults:(NSUserDefaults *)defaults;

--- a/easy-move-resize/EMRPreferences.m
+++ b/easy-move-resize/EMRPreferences.m
@@ -98,6 +98,7 @@
     [self setModifierFlagString:[@[CTRL_KEY, CMD_KEY] componentsJoinedByString:@","]];
     [userDefaults setBool:NO forKey:SHOULD_BRING_WINDOW_TO_FRONT];
     [userDefaults setBool:NO forKey:SHOULD_MIDDLE_CLICK_RESIZE];
+    [userDefaults setBool:NO forKey:RESIZE_ONLY];
     [userDefaults setObject:[NSDictionary dictionary] forKey:DISABLED_APPS_DEFAULTS_KEY];
 }
 
@@ -149,6 +150,13 @@
 }
 -(void)setShouldMiddleClickResize:(BOOL)middleClickResize {
     [userDefaults setBool:middleClickResize forKey:SHOULD_MIDDLE_CLICK_RESIZE];
+}
+
+-(BOOL)resizeOnly {
+    return [userDefaults boolForKey:RESIZE_ONLY];
+}
+-(void)setResizeOnly:(BOOL)resizeOnly {
+    [userDefaults setBool:resizeOnly forKey:RESIZE_ONLY];
 }
 
 @end

--- a/easy-move-resize/en.lproj/MainMenu.xib
+++ b/easy-move-resize/en.lproj/MainMenu.xib
@@ -696,6 +696,12 @@
                         <action selector="toggleMiddleClickResize:" target="494" id="gAe-qW-XIr"/>
                     </connections>
                 </menuItem>
+                <menuItem title="Resize only" id="ErU-VJ-PWr">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="toggleResizeOnly:" target="494" id="GYr-Jb-BKv"/>
+                    </connections>
+                </menuItem>
                 <menuItem isSeparatorItem="YES" id="XPE-bb-yrs"/>
                 <menuItem title="Disable for" enabled="NO" id="ZKn-HI-Yq4">
                     <modifierMask key="keyEquivalentModifierMask"/>
@@ -734,6 +740,7 @@
                 <outlet property="disabledMenu" destination="Q0w-G0-Ppy" id="D3v-HP-HjG"/>
                 <outlet property="lastAppMenu" destination="ZKn-HI-Yq4" id="aO7-eG-bLr"/>
                 <outlet property="middleClickResizeMenu" destination="S2R-bI-Azo" id="c8V-7R-1QY"/>
+                <outlet property="resizeOnlyMenu" destination="ErU-VJ-PWr" id="eXx-DE-rHT"/>
                 <outlet property="shiftMenu" destination="SZL-bI-dng" id="YZk-pM-c3k"/>
                 <outlet property="statusMenu" destination="obP-gH-pam" id="YfI-Jt-Lpf"/>
             </connections>


### PR DESCRIPTION
With this option is possible to use the tool only for resizing and use the built-in support in macOS for ctrl+cmd+click to move windows, i.e:

`defaults write -g NSWindowShouldDragOnGesture -bool true`

Resolves #87 