### PR TITLE
Changed refresh rate to 100hz

### DIFF
--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -2,8 +2,8 @@
 
 // these intervals feel good in experimentation, but maybe in the future we can measure how long
 // the move and resize increments are actually taking and adjust them dynamically for each move/resize?
-static const double kMoveFilterInterval = 0.02;
-static const double kResizeFilterInterval = 0.04;
+static const double kMoveFilterInterval = 0.01;
+static const double kResizeFilterInterval = 0.01;
 
 @interface EMRAppDelegate : NSObject <NSApplicationDelegate> {
     IBOutlet NSMenu *statusMenu;

--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -1,7 +1,6 @@
 #import <Cocoa/Cocoa.h>
 
-// these intervals feel good in experimentation, but maybe in the future we can measure how long
-// the move and resize increments are actually taking and adjust them dynamically for each move/resize?
+// 100hz: refresh every 10ms. Seems like a reasonable default value.
 static const double kMoveFilterInterval = 0.01;
 static const double kResizeFilterInterval = 0.01;
 


### PR DESCRIPTION
Fixes #97.
Changes the deafult refresh rate from 50hz (move) and 25hz (resize) to 100hz for both.
This should not effect performence significantly, and it seems like a better default refresh rate, which does not look completly laggy on monitors with high refresh rate.