### PR TITLE
Move/Resize refresh rate based on monitor refresh rate

### DIFF
--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -1,10 +1,5 @@
 #import <Cocoa/Cocoa.h>
 
-// these intervals feel good in experimentation, but maybe in the future we can measure how long
-// the move and resize increments are actually taking and adjust them dynamically for each move/resize?
-static const double kMoveFilterInterval = 0.02;
-static const double kResizeFilterInterval = 0.04;
-
 @interface EMRAppDelegate : NSObject <NSApplicationDelegate> {
     IBOutlet NSMenu *statusMenu;
     NSStatusItem * statusItem;
@@ -34,5 +29,7 @@ static const double kResizeFilterInterval = 0.04;
 @property (weak) IBOutlet NSMenuItem *disabledAppsMenu;
 @property (weak) IBOutlet NSMenuItem *lastAppMenu;
 @property (nonatomic) BOOL sessionActive;
+@property float moveFilterInterval;
+@property float resizeFilterInterval;
 
 @end


### PR DESCRIPTION
Following on from #102 , this change queries across all screens the minimum refresh interval (maximum refresh rate). The Move/Resize operations are updated at this rate. Note that this utilizes a property which is only available in MacOS 12.0 or newer (Released ~October 2021). If the user is on an older version of MacOS, this code assumes a fixed refresh rate of 60 FPS.

Did some simple local testing (MacOS 26.0, 120 HZ LG Monitor) of Chrome, Finder, iTerm, and a few other apps. Responsiveness was much improved compared to the old fixed values.