### PR TITLE
feat: Independent modifier keys and mouse button for resize

### DIFF
--- a/easy-move-resize.xcodeproj/project.pbxproj
+++ b/easy-move-resize.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		52B5E8F61C513E3D0055C181 /* EMRPreferences.m in Sources */ = {isa = PBXBuildFile; fileRef = 52B5E8F51C513E3D0055C181 /* EMRPreferences.m */; };
 		65CF01651F229C34002259F2 /* EMRPreferencesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 65CF01641F229C34002259F2 /* EMRPreferencesTest.m */; };
+		AA0001011A229C34002259F2 /* EMRMoveResizeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0001021A229C34002259F2 /* EMRMoveResizeTest.m */; };
+		AA0001031A229C34002259F2 /* EMRAppDelegateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0001041A229C34002259F2 /* EMRAppDelegateTest.m */; };
 		6ED47B65183BF3E800859244 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6ED47B64183BF3E800859244 /* Cocoa.framework */; };
 		6ED47B6F183BF3E800859244 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6ED47B6D183BF3E800859244 /* InfoPlist.strings */; };
 		6ED47B71183BF3E800859244 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ED47B70183BF3E800859244 /* main.m */; };
@@ -37,6 +39,8 @@
 		65CF01621F229C34002259F2 /* easy-move-resizeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "easy-move-resizeTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		65CF01641F229C34002259F2 /* EMRPreferencesTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMRPreferencesTest.m; sourceTree = "<group>"; };
 		65CF01661F229C34002259F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AA0001021A229C34002259F2 /* EMRMoveResizeTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMRMoveResizeTest.m; sourceTree = "<group>"; };
+		AA0001041A229C34002259F2 /* EMRAppDelegateTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMRAppDelegateTest.m; sourceTree = "<group>"; };
 		6E238EE0184504BC00E47948 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		6ED47B61183BF3E800859244 /* Easy Move+Resize.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Easy Move+Resize.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6ED47B64183BF3E800859244 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
@@ -84,6 +88,8 @@
 			isa = PBXGroup;
 			children = (
 				65CF01641F229C34002259F2 /* EMRPreferencesTest.m */,
+				AA0001021A229C34002259F2 /* EMRMoveResizeTest.m */,
+				AA0001041A229C34002259F2 /* EMRAppDelegateTest.m */,
 				65CF01661F229C34002259F2 /* Info.plist */,
 			);
 			path = "easy-move-resizeTests";
@@ -263,6 +269,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				65CF01651F229C34002259F2 /* EMRPreferencesTest.m in Sources */,
+				AA0001011A229C34002259F2 /* EMRMoveResizeTest.m in Sources */,
+				AA0001031A229C34002259F2 /* EMRAppDelegateTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -4,27 +4,55 @@
     IBOutlet NSMenu *statusMenu;
     NSStatusItem * statusItem;
     int keyModifierFlags;
+    int resizeKeyModifierFlags;
+    int cachedMoveMouseButton;
+    int cachedResizeMouseButton;
+    BOOL cachedHasConflict;
     NSRunningApplication *lastApp;
+
+    // Programmatic menu items — Move section
+    NSMenuItem *moveAltMenu;
+    NSMenuItem *moveCmdMenu;
+    NSMenuItem *moveCtrlMenu;
+    NSMenuItem *moveShiftMenu;
+    NSMenuItem *moveFnMenu;
+    NSMenuItem *moveMouseButtonLeftMenu;
+    NSMenuItem *moveMouseButtonRightMenu;
+    NSMenuItem *moveMouseButtonMiddleMenu;
+
+    // Programmatic menu items — Resize section
+    NSMenuItem *resizeAltMenu;
+    NSMenuItem *resizeCmdMenu;
+    NSMenuItem *resizeCtrlMenu;
+    NSMenuItem *resizeShiftMenu;
+    NSMenuItem *resizeFnMenu;
+    NSMenuItem *resizeMouseButtonLeftMenu;
+    NSMenuItem *resizeMouseButtonRightMenu;
+    NSMenuItem *resizeMouseButtonMiddleMenu;
+
+    // Programmatic menu items — other
+    NSMenuItem *conflictWarningMenu;
 }
 
 - (int)modifierFlags;
+- (int)resizeModifierFlags;
+- (int)moveMouseButton;
+- (int)resizeMouseButton;
 
-- (void)initMenuItems;
 - (IBAction)modifierToggle:(id)sender;
+- (IBAction)resizeModifierToggle:(id)sender;
 - (IBAction)resetToDefaults:(id)sender;
 - (IBAction)toggleDisabled:(id)sender;
 - (IBAction)toggleBringWindowToFront:(id)sender;
+- (IBAction)toggleResizeOnly:(id)sender;
+- (IBAction)setMoveMouseButton:(id)sender;
+- (IBAction)setResizeMouseButton:(id)sender;
 - (IBAction)disableLastApp:(id)sender;
 - (IBAction)enableDisabledApp:(id)sender;
 
-@property (weak) IBOutlet NSMenuItem *altMenu;
-@property (weak) IBOutlet NSMenuItem *cmdMenu;
-@property (weak) IBOutlet NSMenuItem *ctrlMenu;
-@property (weak) IBOutlet NSMenuItem *shiftMenu;
-@property (weak) IBOutlet NSMenuItem *fnMenu;
+// XIB-wired outlets — kept for items that remain in the XIB
 @property (weak) IBOutlet NSMenuItem *disabledMenu;
 @property (weak) IBOutlet NSMenuItem *bringWindowFrontMenu;
-@property (weak) IBOutlet NSMenuItem *middleClickResizeMenu;
 @property (weak) IBOutlet NSMenuItem *resizeOnlyMenu;
 @property (weak) IBOutlet NSMenuItem *disabledAppsMenu;
 @property (weak) IBOutlet NSMenuItem *lastAppMenu;

--- a/easy-move-resize/EMRAppDelegate.m
+++ b/easy-move-resize/EMRAppDelegate.m
@@ -2,6 +2,10 @@
 #import "EMRMoveResize.h"
 #import "EMRPreferences.h"
 
+#define ALL_MODIFIERS (kCGEventFlagMaskShift | kCGEventFlagMaskCommand | \
+    kCGEventFlagMaskAlphaShift | kCGEventFlagMaskAlternate | \
+    kCGEventFlagMaskControl | kCGEventFlagMaskSecondaryFn)
+
 /* Return the minimum refresh interval (1/refresh rate) across all screens. If the user
  * is on a version of MacOS < 12.0 then 60hz refresh rate is assumed. */
 float getMinRefreshInterval(void) {
@@ -32,57 +36,96 @@ float getMinRefreshInterval(void) {
     return self;
 }
 
+- (void)refreshCachedPreferences {
+    keyModifierFlags = [preferences modifierFlags];
+    resizeKeyModifierFlags = [preferences resizeModifierFlags];
+    cachedMoveMouseButton = [preferences moveMouseButton];
+    cachedResizeMouseButton = [preferences resizeMouseButton];
+    cachedHasConflict = [preferences hasConflictingConfig];
+}
+
+#pragma mark - Event callback
+
 CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, CGEventRef event, void *refcon) {
 
     EMRAppDelegate *ourDelegate = (__bridge EMRAppDelegate*)refcon;
-    int keyModifierFlags = [ourDelegate modifierFlags];
-    bool shouldMiddleClickResize = [ourDelegate shouldMiddleClickResize];
-    bool resizeOnly = [ourDelegate resizeOnly];
-    CGEventType resizeModifierDown = kCGEventRightMouseDown;
-    CGEventType resizeModifierDragged = kCGEventRightMouseDragged;
-    CGEventType resizeModifierUp = kCGEventRightMouseUp;
-    bool handled = NO;
+
+    // Re-enable tap if it was disabled (usually happens on a slow resizing app)
+    if ((type == kCGEventTapDisabledByTimeout || type == kCGEventTapDisabledByUserInput)) {
+        EMRMoveResize* mr = [EMRMoveResize instance];
+        CGEventTapEnable([mr eventTap], true);
+        return event;
+    }
 
     if (![ourDelegate sessionActive]) {
         return event;
     }
 
-    if (keyModifierFlags == 0) {
-        // No modifier keys set. Disable behaviour.
-        return event;
-    }
-    
-    if (shouldMiddleClickResize){
-        resizeModifierDown = kCGEventOtherMouseDown;
-        resizeModifierDragged = kCGEventOtherMouseDragged;
-        resizeModifierUp = kCGEventOtherMouseUp;
-    }
-    
-    EMRMoveResize* moveResize = [EMRMoveResize instance];
+    // Read cached preference values (ivars, not NSUserDefaults)
+    int moveModifiers = ourDelegate->keyModifierFlags;
+    int resizeModifiers = ourDelegate->resizeKeyModifierFlags;
+    int moveBtn = ourDelegate->cachedMoveMouseButton;
+    int resizeBtn = ourDelegate->cachedResizeMouseButton;
+    bool resizeOnly = [ourDelegate resizeOnly];
 
-    if ((type == kCGEventTapDisabledByTimeout || type == kCGEventTapDisabledByUserInput)) {
-        // need to re-enable our eventTap (We got disabled.  Usually happens on a slow resizing app)
-        CGEventTapEnable([moveResize eventTap], true);
+    // Both modifier sets are zero — nothing to do
+    if (moveModifiers == 0 && resizeModifiers == 0) {
         return event;
     }
-    
+
     CGEventFlags flags = CGEventGetFlags(event);
-    if ((flags & (keyModifierFlags)) != (keyModifierFlags)) {
-        // didn't find our expected modifiers; this event isn't for us
+    EMRMoveResize *moveResize = [EMRMoveResize instance];
+
+    // Check if flags match each modifier set with no extra modifiers
+    BOOL moveModifiersMatch = NO;
+    BOOL resizeModifiersMatch = NO;
+
+    if (moveModifiers != 0 && (flags & moveModifiers) == (CGEventFlags)moveModifiers) {
+        int moveIgnored = ALL_MODIFIERS ^ moveModifiers;
+        moveModifiersMatch = !(flags & moveIgnored);
+    }
+    if (resizeModifiers != 0 && (flags & resizeModifiers) == (CGEventFlags)resizeModifiers) {
+        int resizeIgnored = ALL_MODIFIERS ^ resizeModifiers;
+        resizeModifiersMatch = !(flags & resizeIgnored);
+    }
+
+    // Map CGEvent type to button number and event phase
+    int eventButton = -1;
+    BOOL isDown = NO, isDrag = NO, isUp = NO;
+    switch (type) {
+        case kCGEventLeftMouseDown:     eventButton = 0; isDown = YES; break;
+        case kCGEventRightMouseDown:    eventButton = 1; isDown = YES; break;
+        case kCGEventOtherMouseDown:    eventButton = 2; isDown = YES; break;
+        case kCGEventLeftMouseDragged:  eventButton = 0; isDrag = YES; break;
+        case kCGEventRightMouseDragged: eventButton = 1; isDrag = YES; break;
+        case kCGEventOtherMouseDragged: eventButton = 2; isDrag = YES; break;
+        case kCGEventLeftMouseUp:       eventButton = 0; isUp = YES; break;
+        case kCGEventRightMouseUp:      eventButton = 1; isUp = YES; break;
+        case kCGEventOtherMouseUp:      eventButton = 2; isUp = YES; break;
+        default: return event;
+    }
+
+    // Determine if this event matches move, resize, or neither
+    BOOL isForMove = (eventButton == moveBtn && moveModifiersMatch && !resizeOnly);
+    BOOL isForResize = (eventButton == resizeBtn && resizeModifiersMatch);
+
+    // Conflict resolution: if both match, prefer resize
+    if (isForMove && isForResize) {
+        isForMove = NO;
+    }
+
+    // If neither matches and we're not in an active drag, this event isn't for us
+    if (!isForMove && !isForResize && !([moveResize tracking] > 0)) {
         return event;
     }
 
-    int ignoredKeysMask = (kCGEventFlagMaskShift | kCGEventFlagMaskCommand | kCGEventFlagMaskAlphaShift | kCGEventFlagMaskAlternate | kCGEventFlagMaskControl | kCGEventFlagMaskSecondaryFn) ^ keyModifierFlags;
-    
-    if (flags & ignoredKeysMask) {
-        // also ignore this event if we've got extra modifiers (i.e. holding down Cmd+Ctrl+Alt should not invoke our action)
-        return event;
-    }
+    BOOL handled = NO;
 
-    if ((type == kCGEventLeftMouseDown && !resizeOnly)
-            || type == resizeModifierDown) {
+    // --- MOUSE DOWN: capture window, set isResizing, compute resize direction ---
+    if (isDown && (isForMove || isForResize)) {
         CGPoint mouseLocation = CGEventGetLocation(event);
         [moveResize setTracking:CACurrentMediaTime()];
+        [moveResize setIsResizing:isForResize];
 
         AXUIElementRef _systemWideElement;
         AXUIElementRef _clickedWindow = NULL;
@@ -104,13 +147,14 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
             }
         }
         CFRelease(_systemWideElement);
-        
+
         pid_t PID;
         NSRunningApplication* app;
         if(!AXUIElementGetPid(_clickedWindow, &PID)) {
             app = [NSRunningApplication runningApplicationWithProcessIdentifier:PID];
             if ([[ourDelegate getDisabledApps] objectForKey:[app bundleIdentifier]] != nil) {
                 [moveResize setTracking:0];
+                [moveResize setIsResizing:NO];
                 return event;
             }
             [ourDelegate setMostRecentApp:app];
@@ -122,7 +166,7 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
             }
             AXUIElementPerformAction(_clickedWindow, kAXRaiseAction);
         }
-        
+
         CFTypeRef _cPosition = nil;
         NSPoint cTopLeft;
         if (AXUIElementCopyAttributeValue((AXUIElementRef)_clickedWindow, (__bridge CFStringRef)NSAccessibilityPositionAttribute, &_cPosition) == kAXErrorSuccess) {
@@ -132,157 +176,147 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
             }
             CFRelease(_cPosition);
         }
-        
+
         cTopLeft.x = (int) cTopLeft.x;
         cTopLeft.y = (int) cTopLeft.y;
 
         [moveResize setWndPosition:cTopLeft];
         [moveResize setWindow:_clickedWindow];
         if (_clickedWindow != nil) CFRelease(_clickedWindow);
-        handled = YES;
-    }
 
-    if (type == kCGEventLeftMouseDragged
-            && [moveResize tracking] > 0) {
-        AXUIElementRef _clickedWindow = [moveResize window];
-        double deltaX = CGEventGetDoubleValueField(event, kCGMouseEventDeltaX);
-        double deltaY = CGEventGetDoubleValueField(event, kCGMouseEventDeltaY);
+        // If this is a resize, compute resize direction from click position in window thirds
+        if (isForResize) {
+            AXUIElementRef _resizeWindow = [moveResize window];
+            struct ResizeSection resizeSection;
 
-        NSPoint cTopLeft = [moveResize wndPosition];
-        NSPoint thePoint;
-        thePoint.x = cTopLeft.x + deltaX;
-        thePoint.y = cTopLeft.y + deltaY;
-        [moveResize setWndPosition:thePoint];
-        CFTypeRef _position;
+            CGPoint clickPoint = mouseLocation;
+            clickPoint.x -= cTopLeft.x;
+            clickPoint.y -= cTopLeft.y;
 
-        // actually applying the change is expensive, so only do it every kMoveFilterInterval seconds
-        if (CACurrentMediaTime() - [moveResize tracking] > ourDelegate.moveFilterInterval) {
-            _position = (CFTypeRef) (AXValueCreate(kAXValueCGPointType, (const void *) &thePoint));
-            AXUIElementSetAttributeValue(_clickedWindow, (__bridge CFStringRef) NSAccessibilityPositionAttribute, (CFTypeRef *) _position);
-            if (_position != NULL) CFRelease(_position);
-            [moveResize setTracking:CACurrentMediaTime()];
-        }
-        handled = YES;
-    }
+            CFTypeRef _cSize;
+            NSSize cSize;
+            if (!(AXUIElementCopyAttributeValue((AXUIElementRef)_resizeWindow, (__bridge CFStringRef)NSAccessibilitySizeAttribute, &_cSize) == kAXErrorSuccess)
+                    || !AXValueGetValue(_cSize, kAXValueCGSizeType, (void *)&cSize)) {
+                NSLog(@"ERROR: Could not decode size");
+                [moveResize setTracking:0];
+                [moveResize setIsResizing:NO];
+                return NULL;
+            }
+            CFRelease(_cSize);
 
-    if (type == resizeModifierDown) {
-        AXUIElementRef _clickedWindow = [moveResize window];
+            NSSize wndSize = cSize;
 
-        // on resizeModifierDown click, record which direction we should resize in on the drag
-        struct ResizeSection resizeSection;
-
-        CGPoint clickPoint = CGEventGetLocation(event);
-
-        NSPoint cTopLeft = [moveResize wndPosition];
-
-        clickPoint.x -= cTopLeft.x;
-        clickPoint.y -= cTopLeft.y;
-
-        CFTypeRef _cSize;
-        NSSize cSize;
-        if (!(AXUIElementCopyAttributeValue((AXUIElementRef)_clickedWindow, (__bridge CFStringRef)NSAccessibilitySizeAttribute, &_cSize) == kAXErrorSuccess)
-                || !AXValueGetValue(_cSize, kAXValueCGSizeType, (void *)&cSize)) {
-            NSLog(@"ERROR: Could not decode size");
-            return NULL;
-        }
-        CFRelease(_cSize);
-
-        NSSize wndSize = cSize;
-
-        if (clickPoint.x < wndSize.width/3) {
-            resizeSection.xResizeDirection = left;
-        } else if (clickPoint.x > 2*wndSize.width/3) {
-            resizeSection.xResizeDirection = right;
-        } else {
-            resizeSection.xResizeDirection = noX;
-        }
-
-        if (clickPoint.y < wndSize.height/3) {
-            resizeSection.yResizeDirection = bottom;
-        } else  if (clickPoint.y > 2*wndSize.height/3) {
-            resizeSection.yResizeDirection = top;
-        } else {
-            resizeSection.yResizeDirection = noY;
-        }
-
-        [moveResize setWndSize:wndSize];
-        [moveResize setResizeSection:resizeSection];
-        handled = YES;
-    }
-
-    if (type == resizeModifierDragged
-            && [moveResize tracking] > 0) {
-        AXUIElementRef _clickedWindow = [moveResize window];
-        struct ResizeSection resizeSection = [moveResize resizeSection];
-        int deltaX = (int) CGEventGetDoubleValueField(event, kCGMouseEventDeltaX);
-        int deltaY = (int) CGEventGetDoubleValueField(event, kCGMouseEventDeltaY);
-
-        NSPoint cTopLeft = [moveResize wndPosition];
-        NSSize wndSize = [moveResize wndSize];
-
-        switch (resizeSection.xResizeDirection) {
-            case right:
-                wndSize.width += deltaX;
-                break;
-            case left:
-                wndSize.width -= deltaX;
-                cTopLeft.x += deltaX;
-                break;
-            case noX:
-                // nothing to do
-                break;
-            default:
-                [NSException raise:@"Unknown xResizeSection" format:@"No case for %d", resizeSection.xResizeDirection];
-        }
-
-        switch (resizeSection.yResizeDirection) {
-            case top:
-                wndSize.height += deltaY;
-                break;
-            case bottom:
-                wndSize.height -= deltaY;
-                cTopLeft.y += deltaY;
-                break;
-            case noY:
-                // nothing to do
-                break;
-            default:
-                [NSException raise:@"Unknown yResizeSection" format:@"No case for %d", resizeSection.yResizeDirection];
-        }
-
-        [moveResize setWndPosition:cTopLeft];
-        [moveResize setWndSize:wndSize];
-
-        // actually applying the change is expensive, so only do it every kResizeFilterInterval events
-        if (CACurrentMediaTime() - [moveResize tracking] > ourDelegate.resizeFilterInterval) {
-            // only make a call to update the position if we need to
-            if (resizeSection.xResizeDirection == left || resizeSection.yResizeDirection == bottom) {
-                CFTypeRef _position = (CFTypeRef)(AXValueCreate(kAXValueCGPointType, (const void *)&cTopLeft));
-                AXUIElementSetAttributeValue(_clickedWindow, (__bridge CFStringRef)NSAccessibilityPositionAttribute, (CFTypeRef *)_position);
-                CFRelease(_position);
+            if (clickPoint.x < wndSize.width/3) {
+                resizeSection.xResizeDirection = left;
+            } else if (clickPoint.x > 2*wndSize.width/3) {
+                resizeSection.xResizeDirection = right;
+            } else {
+                resizeSection.xResizeDirection = noX;
             }
 
-            CFTypeRef _size = (CFTypeRef)(AXValueCreate(kAXValueCGSizeType, (const void *)&wndSize));
-            AXUIElementSetAttributeValue((AXUIElementRef)_clickedWindow, (__bridge CFStringRef)NSAccessibilitySizeAttribute, (CFTypeRef *)_size);
-            CFRelease(_size);
-            [moveResize setTracking:CACurrentMediaTime()];
+            if (clickPoint.y < wndSize.height/3) {
+                resizeSection.yResizeDirection = bottom;
+            } else if (clickPoint.y > 2*wndSize.height/3) {
+                resizeSection.yResizeDirection = top;
+            } else {
+                resizeSection.yResizeDirection = noY;
+            }
+
+            [moveResize setWndSize:wndSize];
+            [moveResize setResizeSection:resizeSection];
+        }
+
+        handled = YES;
+    }
+
+    // --- MOUSE DRAG: move or resize based on isResizing ---
+    if (isDrag && [moveResize tracking] > 0) {
+        if ([moveResize isResizing]) {
+            // Resize drag
+            AXUIElementRef _clickedWindow = [moveResize window];
+            struct ResizeSection resizeSection = [moveResize resizeSection];
+            int deltaX = (int) CGEventGetDoubleValueField(event, kCGMouseEventDeltaX);
+            int deltaY = (int) CGEventGetDoubleValueField(event, kCGMouseEventDeltaY);
+
+            NSPoint cTopLeft = [moveResize wndPosition];
+            NSSize wndSize = [moveResize wndSize];
+
+            switch (resizeSection.xResizeDirection) {
+                case right:
+                    wndSize.width += deltaX;
+                    break;
+                case left:
+                    wndSize.width -= deltaX;
+                    cTopLeft.x += deltaX;
+                    break;
+                case noX:
+                    break;
+                default:
+                    [NSException raise:@"Unknown xResizeSection" format:@"No case for %d", resizeSection.xResizeDirection];
+            }
+
+            switch (resizeSection.yResizeDirection) {
+                case top:
+                    wndSize.height += deltaY;
+                    break;
+                case bottom:
+                    wndSize.height -= deltaY;
+                    cTopLeft.y += deltaY;
+                    break;
+                case noY:
+                    break;
+                default:
+                    [NSException raise:@"Unknown yResizeSection" format:@"No case for %d", resizeSection.yResizeDirection];
+            }
+
+            [moveResize setWndPosition:cTopLeft];
+            [moveResize setWndSize:wndSize];
+
+            if (CACurrentMediaTime() - [moveResize tracking] > ourDelegate.resizeFilterInterval) {
+                if (resizeSection.xResizeDirection == left || resizeSection.yResizeDirection == bottom) {
+                    CFTypeRef _position = (CFTypeRef)(AXValueCreate(kAXValueCGPointType, (const void *)&cTopLeft));
+                    AXUIElementSetAttributeValue(_clickedWindow, (__bridge CFStringRef)NSAccessibilityPositionAttribute, (CFTypeRef *)_position);
+                    CFRelease(_position);
+                }
+
+                CFTypeRef _size = (CFTypeRef)(AXValueCreate(kAXValueCGSizeType, (const void *)&wndSize));
+                AXUIElementSetAttributeValue((AXUIElementRef)_clickedWindow, (__bridge CFStringRef)NSAccessibilitySizeAttribute, (CFTypeRef *)_size);
+                CFRelease(_size);
+                [moveResize setTracking:CACurrentMediaTime()];
+            }
+        } else {
+            // Move drag
+            AXUIElementRef _clickedWindow = [moveResize window];
+            double deltaX = CGEventGetDoubleValueField(event, kCGMouseEventDeltaX);
+            double deltaY = CGEventGetDoubleValueField(event, kCGMouseEventDeltaY);
+
+            NSPoint cTopLeft = [moveResize wndPosition];
+            NSPoint thePoint;
+            thePoint.x = cTopLeft.x + deltaX;
+            thePoint.y = cTopLeft.y + deltaY;
+            [moveResize setWndPosition:thePoint];
+
+            if (CACurrentMediaTime() - [moveResize tracking] > ourDelegate.moveFilterInterval) {
+                CFTypeRef _position = (CFTypeRef)(AXValueCreate(kAXValueCGPointType, (const void *)&thePoint));
+                AXUIElementSetAttributeValue(_clickedWindow, (__bridge CFStringRef)NSAccessibilityPositionAttribute, (CFTypeRef *)_position);
+                if (_position != NULL) CFRelease(_position);
+                [moveResize setTracking:CACurrentMediaTime()];
+            }
         }
         handled = YES;
     }
 
-    if ((type == kCGEventLeftMouseUp || type == resizeModifierUp)
-        && [moveResize tracking] > 0) {
+    // --- MOUSE UP: clear tracking ---
+    if (isUp && [moveResize tracking] > 0) {
         [moveResize setTracking:0];
+        [moveResize setIsResizing:NO];
         handled = YES;
     }
-    
-    if (handled) {
-        return NULL;
-    }
-    else {
-        return event;
-    }
+
+    return handled ? NULL : event;
 }
+
+#pragma mark - Application lifecycle
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
@@ -298,17 +332,17 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
             &kCFTypeDictionaryValueCallBacks);
 
     if (!AXIsProcessTrustedWithOptions(options)) {
-        // don't have permission to do our thing right now... AXIsProcessTrustedWithOptions prompted the user to fix
-        // this, so hopefully on next launch we'll be good to go
         NSLog(@"Missing permissions");
-        exit(1);
+        // Skip exit during unit tests so the test runner can bootstrap
+        if (NSClassFromString(@"XCTestCase") == nil) {
+            exit(1);
+        }
+        return;
     }
-    
-    [self initMenuItems];
 
-    // Retrieve the Key press modifier flags to activate move/resize actions.
-    keyModifierFlags = [preferences modifierFlags];
-    
+    [self buildMenu];
+    [self refreshCachedPreferences];
+
     CFRunLoopSourceRef runLoopSource;
 
     CGEventMask eventMask = CGEventMaskBit( kCGEventLeftMouseDown )
@@ -336,7 +370,6 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
     runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0);
 
-
     EMRMoveResize *moveResize = [EMRMoveResize instance];
     [moveResize setEventTap:eventTap];
     [moveResize setRunLoopSource:runLoopSource];
@@ -355,7 +388,7 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
             selector:@selector(becameInactive:)
             name:NSWorkspaceSessionDidResignActiveNotification
             object:nil];
-    
+
     [self reconstructDisabledAppsSubmenu];
 }
 
@@ -386,63 +419,260 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     CFRunLoopRemoveSource(CFRunLoopGetCurrent(), [moveResize runLoopSource], kCFRunLoopCommonModes);
 }
 
-- (void)initMenuItems {
-    [_altMenu setState:0];
-    [_cmdMenu setState:0];
-    [_ctrlMenu setState:0];
-    [_shiftMenu setState:0];
-    [_fnMenu setState:0];
-    [_disabledMenu setState:0];
-    [_bringWindowFrontMenu setState:0];
-    [_middleClickResizeMenu setState:0];
+#pragma mark - Menu construction (programmatic)
 
-    bool shouldBringWindowToFront = [preferences shouldBringWindowToFront];
-    bool shouldMiddleClickResize = [preferences shouldMiddleClickResize];
-    bool resizeOnly = [preferences resizeOnly];
-
-    if(shouldBringWindowToFront){
-        [_bringWindowFrontMenu setState:1];
-    }
-    if(shouldMiddleClickResize){
-        [_middleClickResizeMenu setState:1];
-    }
-    if(resizeOnly){
-        [_resizeOnlyMenu setState:1];
-    }
-    
-    NSSet* flags = [preferences getFlagStringSet];
-    if ([flags containsObject:ALT_KEY]) {
-        [_altMenu setState:1];
-    }
-    if ([flags containsObject:CMD_KEY]) {
-        [_cmdMenu setState:1];
-    }
-    if ([flags containsObject:CTRL_KEY]) {
-        [_ctrlMenu setState:1];
-    }
-    if ([flags containsObject:SHIFT_KEY]) {
-        [_shiftMenu setState:1];
-    }
-    if ([flags containsObject:FN_KEY]) {
-        [_fnMenu setState:1];
-    }
+- (NSMenuItem *)createModifierItem:(NSString *)title action:(SEL)action state:(BOOL)on {
+    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:title action:action keyEquivalent:@""];
+    [item setTarget:self];
+    [item setState:on ? NSControlStateValueOn : NSControlStateValueOff];
+    return item;
 }
+
+- (NSMenuItem *)createMouseButtonSubmenu:(NSString *)label
+                            leftItem:(NSMenuItem **)outLeft
+                           rightItem:(NSMenuItem **)outRight
+                          middleItem:(NSMenuItem **)outMiddle
+                              action:(SEL)action
+                       selectedButton:(int)selected {
+    NSMenu *sub = [[NSMenu alloc] init];
+    NSMenuItem *leftItem = [[NSMenuItem alloc] initWithTitle:@"Left" action:action keyEquivalent:@""];
+    [leftItem setTarget:self];
+    [leftItem setTag:EMRMouseButtonLeft];
+    [leftItem setState:(selected == EMRMouseButtonLeft) ? NSControlStateValueOn : NSControlStateValueOff];
+    [sub addItem:leftItem];
+
+    NSMenuItem *rightItem = [[NSMenuItem alloc] initWithTitle:@"Right" action:action keyEquivalent:@""];
+    [rightItem setTarget:self];
+    [rightItem setTag:EMRMouseButtonRight];
+    [rightItem setState:(selected == EMRMouseButtonRight) ? NSControlStateValueOn : NSControlStateValueOff];
+    [sub addItem:rightItem];
+
+    NSMenuItem *middleItem = [[NSMenuItem alloc] initWithTitle:@"Middle" action:action keyEquivalent:@""];
+    [middleItem setTarget:self];
+    [middleItem setTag:EMRMouseButtonMiddle];
+    [middleItem setState:(selected == EMRMouseButtonMiddle) ? NSControlStateValueOn : NSControlStateValueOff];
+    [sub addItem:middleItem];
+
+    *outLeft = leftItem;
+    *outRight = rightItem;
+    *outMiddle = middleItem;
+
+    NSMenuItem *container = [[NSMenuItem alloc] initWithTitle:label action:nil keyEquivalent:@""];
+    [container setSubmenu:sub];
+    return container;
+}
+
+- (void)buildMenu {
+    // XIB provides: [0] "Easy Move+Resize" (title), [1] "Disabled", [2] separator,
+    //               [3] "Bring Window to Front", [4] "Resize only", ...
+    // We insert programmatic Move/Resize sections at index 3 (before "Bring Window to Front").
+    NSInteger insertIdx = 3;
+
+    // --- Move section ---
+    NSSet *moveFlags = [preferences getFlagStringSet];
+    BOOL moveResizeOnly = [preferences resizeOnly];
+
+    NSMenuItem *moveHeader = [[NSMenuItem alloc] initWithTitle:@"Move:" action:nil keyEquivalent:@""];
+    [moveHeader setEnabled:NO];
+    [statusMenu insertItem:moveHeader atIndex:insertIdx++];
+
+    moveAltMenu = [self createModifierItem:ALT_KEY action:@selector(modifierToggle:) state:[moveFlags containsObject:ALT_KEY]];
+    [moveAltMenu setIndentationLevel:1];
+    [statusMenu insertItem:moveAltMenu atIndex:insertIdx++];
+
+    moveCmdMenu = [self createModifierItem:CMD_KEY action:@selector(modifierToggle:) state:[moveFlags containsObject:CMD_KEY]];
+    [moveCmdMenu setIndentationLevel:1];
+    [statusMenu insertItem:moveCmdMenu atIndex:insertIdx++];
+
+    moveCtrlMenu = [self createModifierItem:CTRL_KEY action:@selector(modifierToggle:) state:[moveFlags containsObject:CTRL_KEY]];
+    [moveCtrlMenu setIndentationLevel:1];
+    [statusMenu insertItem:moveCtrlMenu atIndex:insertIdx++];
+
+    moveShiftMenu = [self createModifierItem:SHIFT_KEY action:@selector(modifierToggle:) state:[moveFlags containsObject:SHIFT_KEY]];
+    [moveShiftMenu setIndentationLevel:1];
+    [statusMenu insertItem:moveShiftMenu atIndex:insertIdx++];
+
+    moveFnMenu = [self createModifierItem:FN_KEY action:@selector(modifierToggle:) state:[moveFlags containsObject:FN_KEY]];
+    [moveFnMenu setIndentationLevel:1];
+    [statusMenu insertItem:moveFnMenu atIndex:insertIdx++];
+
+    int moveBtn = [preferences moveMouseButton];
+    NSMenuItem *tmpLeft, *tmpRight, *tmpMiddle;
+    NSMenuItem *moveBtnContainer = [self createMouseButtonSubmenu:@"Mouse Button"
+                                                        leftItem:&tmpLeft
+                                                       rightItem:&tmpRight
+                                                      middleItem:&tmpMiddle
+                                                          action:@selector(setMoveMouseButton:)
+                                                   selectedButton:moveBtn];
+    moveMouseButtonLeftMenu = tmpLeft;
+    moveMouseButtonRightMenu = tmpRight;
+    moveMouseButtonMiddleMenu = tmpMiddle;
+    [moveBtnContainer setIndentationLevel:1];
+    [statusMenu insertItem:moveBtnContainer atIndex:insertIdx++];
+
+    // Separator between Move and Resize
+    [statusMenu insertItem:[NSMenuItem separatorItem] atIndex:insertIdx++];
+
+    // --- Resize section ---
+    NSSet *resizeFlags = [preferences getResizeFlagStringSet];
+
+    NSMenuItem *resizeHeader = [[NSMenuItem alloc] initWithTitle:@"Resize:" action:nil keyEquivalent:@""];
+    [resizeHeader setEnabled:NO];
+    [statusMenu insertItem:resizeHeader atIndex:insertIdx++];
+
+    resizeAltMenu = [self createModifierItem:ALT_KEY action:@selector(resizeModifierToggle:) state:[resizeFlags containsObject:ALT_KEY]];
+    [resizeAltMenu setIndentationLevel:1];
+    [statusMenu insertItem:resizeAltMenu atIndex:insertIdx++];
+
+    resizeCmdMenu = [self createModifierItem:CMD_KEY action:@selector(resizeModifierToggle:) state:[resizeFlags containsObject:CMD_KEY]];
+    [resizeCmdMenu setIndentationLevel:1];
+    [statusMenu insertItem:resizeCmdMenu atIndex:insertIdx++];
+
+    resizeCtrlMenu = [self createModifierItem:CTRL_KEY action:@selector(resizeModifierToggle:) state:[resizeFlags containsObject:CTRL_KEY]];
+    [resizeCtrlMenu setIndentationLevel:1];
+    [statusMenu insertItem:resizeCtrlMenu atIndex:insertIdx++];
+
+    resizeShiftMenu = [self createModifierItem:SHIFT_KEY action:@selector(resizeModifierToggle:) state:[resizeFlags containsObject:SHIFT_KEY]];
+    [resizeShiftMenu setIndentationLevel:1];
+    [statusMenu insertItem:resizeShiftMenu atIndex:insertIdx++];
+
+    resizeFnMenu = [self createModifierItem:FN_KEY action:@selector(resizeModifierToggle:) state:[resizeFlags containsObject:FN_KEY]];
+    [resizeFnMenu setIndentationLevel:1];
+    [statusMenu insertItem:resizeFnMenu atIndex:insertIdx++];
+
+    int resizeBtn = [preferences resizeMouseButton];
+    NSMenuItem *tmpLeft2, *tmpRight2, *tmpMiddle2;
+    NSMenuItem *resizeBtnContainer = [self createMouseButtonSubmenu:@"Mouse Button"
+                                                           leftItem:&tmpLeft2
+                                                          rightItem:&tmpRight2
+                                                         middleItem:&tmpMiddle2
+                                                             action:@selector(setResizeMouseButton:)
+                                                      selectedButton:resizeBtn];
+    resizeMouseButtonLeftMenu = tmpLeft2;
+    resizeMouseButtonRightMenu = tmpRight2;
+    resizeMouseButtonMiddleMenu = tmpMiddle2;
+    [resizeBtnContainer setIndentationLevel:1];
+    [statusMenu insertItem:resizeBtnContainer atIndex:insertIdx++];
+
+    // Conflict warning (hidden by default, shown when config conflicts)
+    conflictWarningMenu = [[NSMenuItem alloc] initWithTitle:@"\u26A0\uFE0F Move and Resize have identical settings" action:nil keyEquivalent:@""];
+    [conflictWarningMenu setEnabled:NO];
+    [conflictWarningMenu setHidden:YES];
+    [statusMenu insertItem:conflictWarningMenu atIndex:insertIdx++];
+
+    // Separator before "Bring Window to Front"
+    [statusMenu insertItem:[NSMenuItem separatorItem] atIndex:insertIdx++];
+
+    // --- Non-programmatic items (from XIB) follow: Bring Window to Front, Resize only, etc. ---
+    // Set their initial states
+    [_disabledMenu setState:NSControlStateValueOff];
+    [_bringWindowFrontMenu setState:[preferences shouldBringWindowToFront] ? NSControlStateValueOn : NSControlStateValueOff];
+    [_resizeOnlyMenu setState:moveResizeOnly ? NSControlStateValueOn : NSControlStateValueOff];
+
+    // Grey out Move section when resizeOnly is on
+    [self updateMoveMenuEnabled:!moveResizeOnly];
+
+    // Update conflict warning visibility
+    [self updateConflictWarning];
+}
+
+- (void)updateMoveMenuEnabled:(BOOL)enabled {
+    [moveAltMenu setEnabled:enabled];
+    [moveCmdMenu setEnabled:enabled];
+    [moveCtrlMenu setEnabled:enabled];
+    [moveShiftMenu setEnabled:enabled];
+    [moveFnMenu setEnabled:enabled];
+    // Mouse button submenu parent
+    NSMenuItem *moveBtnParent = [moveMouseButtonLeftMenu parentItem];
+    if (moveBtnParent == nil) {
+        // Find parent by traversing — the submenu container is the item whose submenu contains our items
+        for (NSInteger i = 0; i < [statusMenu numberOfItems]; i++) {
+            NSMenuItem *item = [statusMenu itemAtIndex:i];
+            if ([[item submenu] indexOfItem:moveMouseButtonLeftMenu] != -1) {
+                moveBtnParent = item;
+                break;
+            }
+        }
+    }
+    [moveBtnParent setEnabled:enabled];
+}
+
+- (void)updateConflictWarning {
+    BOOL conflict = [preferences hasConflictingConfig];
+    [conflictWarningMenu setHidden:!conflict];
+}
+
+- (void)updateMouseButtonRadioState:(int)selectedButton
+                               left:(NSMenuItem *)leftItem
+                              right:(NSMenuItem *)rightItem
+                             middle:(NSMenuItem *)middleItem {
+    [leftItem setState:(selectedButton == EMRMouseButtonLeft) ? NSControlStateValueOn : NSControlStateValueOff];
+    [rightItem setState:(selectedButton == EMRMouseButtonRight) ? NSControlStateValueOn : NSControlStateValueOff];
+    [middleItem setState:(selectedButton == EMRMouseButtonMiddle) ? NSControlStateValueOn : NSControlStateValueOff];
+}
+
+- (void)syncMenuStatesFromPreferences {
+    // Move modifier checkmarks
+    NSSet *moveFlags = [preferences getFlagStringSet];
+    [moveAltMenu setState:[moveFlags containsObject:ALT_KEY] ? NSControlStateValueOn : NSControlStateValueOff];
+    [moveCmdMenu setState:[moveFlags containsObject:CMD_KEY] ? NSControlStateValueOn : NSControlStateValueOff];
+    [moveCtrlMenu setState:[moveFlags containsObject:CTRL_KEY] ? NSControlStateValueOn : NSControlStateValueOff];
+    [moveShiftMenu setState:[moveFlags containsObject:SHIFT_KEY] ? NSControlStateValueOn : NSControlStateValueOff];
+    [moveFnMenu setState:[moveFlags containsObject:FN_KEY] ? NSControlStateValueOn : NSControlStateValueOff];
+
+    // Resize modifier checkmarks
+    NSSet *resizeFlags = [preferences getResizeFlagStringSet];
+    [resizeAltMenu setState:[resizeFlags containsObject:ALT_KEY] ? NSControlStateValueOn : NSControlStateValueOff];
+    [resizeCmdMenu setState:[resizeFlags containsObject:CMD_KEY] ? NSControlStateValueOn : NSControlStateValueOff];
+    [resizeCtrlMenu setState:[resizeFlags containsObject:CTRL_KEY] ? NSControlStateValueOn : NSControlStateValueOff];
+    [resizeShiftMenu setState:[resizeFlags containsObject:SHIFT_KEY] ? NSControlStateValueOn : NSControlStateValueOff];
+    [resizeFnMenu setState:[resizeFlags containsObject:FN_KEY] ? NSControlStateValueOn : NSControlStateValueOff];
+
+    // Mouse button radio states
+    [self updateMouseButtonRadioState:[preferences moveMouseButton]
+                                 left:moveMouseButtonLeftMenu right:moveMouseButtonRightMenu middle:moveMouseButtonMiddleMenu];
+    [self updateMouseButtonRadioState:[preferences resizeMouseButton]
+                                 left:resizeMouseButtonLeftMenu right:resizeMouseButtonRightMenu middle:resizeMouseButtonMiddleMenu];
+
+    // Other toggles
+    [_bringWindowFrontMenu setState:[preferences shouldBringWindowToFront] ? NSControlStateValueOn : NSControlStateValueOff];
+    [_resizeOnlyMenu setState:[preferences resizeOnly] ? NSControlStateValueOn : NSControlStateValueOff];
+    [_disabledMenu setState:NSControlStateValueOff];
+
+    // Resize-only greys out Move section
+    [self updateMoveMenuEnabled:![preferences resizeOnly]];
+
+    // Conflict warning
+    [self updateConflictWarning];
+}
+
+#pragma mark - IBActions
 
 - (IBAction)modifierToggle:(id)sender {
     NSMenuItem *menu = (NSMenuItem*)sender;
     BOOL newState = ![menu state];
     [menu setState:newState];
     [preferences setModifierKey:[menu title] enabled:newState];
-    keyModifierFlags = [preferences modifierFlags];
+    [self refreshCachedPreferences];
+    [self updateConflictWarning];
+}
+
+- (IBAction)resizeModifierToggle:(id)sender {
+    NSMenuItem *menu = (NSMenuItem*)sender;
+    BOOL newState = ![menu state];
+    [menu setState:newState];
+    [preferences setResizeModifierKey:[menu title] enabled:newState];
+    [self refreshCachedPreferences];
+    [self updateConflictWarning];
 }
 
 - (IBAction)resetToDefaults:(id)sender {
     EMRMoveResize* moveResize = [EMRMoveResize instance];
     [preferences setToDefaults];
-    [self initMenuItems];
+    [self syncMenuStatesFromPreferences];
     [self setMenusEnabled:YES];
     [self enableRunLoopSource:moveResize];
-    keyModifierFlags = [preferences modifierFlags];
+    [self refreshCachedPreferences];
 }
 
 - (IBAction)toggleBringWindowToFront:(id)sender {
@@ -452,23 +682,15 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     [preferences setShouldBringWindowToFront:newState];
 }
 
-- (IBAction)toggleMiddleClickResize:(id)sender {
-    NSMenuItem *menu = (NSMenuItem*)sender;
-    BOOL newState = ![menu state];
-    [menu setState:newState];
-    [preferences setShouldMiddleClickResize:newState];
-}
 
 - (IBAction)toggleDisabled:(id)sender {
     EMRMoveResize* moveResize = [EMRMoveResize instance];
     if ([_disabledMenu state] == 0) {
-        // We are enabled, disable
         [_disabledMenu setState:YES];
         [self setMenusEnabled:NO];
         [self disableRunLoopSource:moveResize];
     }
     else {
-        // We are disabled, enable
         [_disabledMenu setState:NO];
         [self setMenusEnabled:YES];
         [self enableRunLoopSource:moveResize];
@@ -480,6 +702,25 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     BOOL newState = ![menu state];
     [menu setState:newState];
     [preferences setResizeOnly:newState];
+    [self updateMoveMenuEnabled:!newState];
+}
+
+- (IBAction)setMoveMouseButton:(id)sender {
+    NSMenuItem *menu = (NSMenuItem*)sender;
+    int button = (int)[menu tag];
+    [preferences setMoveMouseButton:button];
+    [self updateMouseButtonRadioState:button left:moveMouseButtonLeftMenu right:moveMouseButtonRightMenu middle:moveMouseButtonMiddleMenu];
+    [self refreshCachedPreferences];
+    [self updateConflictWarning];
+}
+
+- (IBAction)setResizeMouseButton:(id)sender {
+    NSMenuItem *menu = (NSMenuItem*)sender;
+    int button = (int)[menu tag];
+    [preferences setResizeMouseButton:button];
+    [self updateMouseButtonRadioState:button left:resizeMouseButtonLeftMenu right:resizeMouseButtonRightMenu middle:resizeMouseButtonMiddleMenu];
+    [self refreshCachedPreferences];
+    [self updateConflictWarning];
 }
 
 - (IBAction)disableLastApp:(id)sender {
@@ -497,8 +738,19 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     [self reconstructDisabledAppsSubmenu];
 }
 
+#pragma mark - Accessor methods
+
 - (int)modifierFlags {
     return keyModifierFlags;
+}
+- (int)resizeModifierFlags {
+    return resizeKeyModifierFlags;
+}
+- (int)moveMouseButton {
+    return cachedMoveMouseButton;
+}
+- (int)resizeMouseButton {
+    return cachedResizeMouseButton;
 }
 - (void) setMostRecentApp:(NSRunningApplication*)app {
     lastApp = app;
@@ -511,21 +763,33 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 -(BOOL)shouldBringWindowToFront {
     return [preferences shouldBringWindowToFront];
 }
--(BOOL)shouldMiddleClickResize {
-    return [preferences shouldMiddleClickResize];
-}
 -(BOOL)resizeOnly {
     return [preferences resizeOnly];
 }
 
 - (void)setMenusEnabled:(BOOL)enabled {
-    [_altMenu setEnabled:enabled];
-    [_cmdMenu setEnabled:enabled];
-    [_ctrlMenu setEnabled:enabled];
-    [_shiftMenu setEnabled:enabled];
-    [_fnMenu setEnabled:enabled];
+    // Move section
+    [moveAltMenu setEnabled:enabled];
+    [moveCmdMenu setEnabled:enabled];
+    [moveCtrlMenu setEnabled:enabled];
+    [moveShiftMenu setEnabled:enabled];
+    [moveFnMenu setEnabled:enabled];
+
+    // Resize section
+    [resizeAltMenu setEnabled:enabled];
+    [resizeCmdMenu setEnabled:enabled];
+    [resizeCtrlMenu setEnabled:enabled];
+    [resizeShiftMenu setEnabled:enabled];
+    [resizeFnMenu setEnabled:enabled];
+
+    // Other items
     [_bringWindowFrontMenu setEnabled:enabled];
-    [_middleClickResizeMenu setEnabled:enabled];
+    [_resizeOnlyMenu setEnabled:enabled];
+
+    // When re-enabling, respect resizeOnly state for Move section
+    if (enabled && [preferences resizeOnly]) {
+        [self updateMoveMenuEnabled:NO];
+    }
 }
 
 - (void)reconstructDisabledAppsSubmenu {

--- a/easy-move-resize/EMRAppDelegate.m
+++ b/easy-move-resize/EMRAppDelegate.m
@@ -320,6 +320,13 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
+    // Skip the entire accessibility check when running under XCTest.
+    // AXIsProcessTrustedWithOptions with kAXTrustedCheckOptionPrompt triggers
+    // a system modal dialog, which blocks the test runner.
+    if (NSClassFromString(@"XCTestCase") != nil) {
+        return;
+    }
+
     const void * keys[] = { kAXTrustedCheckOptionPrompt };
     const void * values[] = { kCFBooleanTrue };
 
@@ -333,11 +340,7 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
     if (!AXIsProcessTrustedWithOptions(options)) {
         NSLog(@"Missing permissions");
-        // Skip exit during unit tests so the test runner can bootstrap
-        if (NSClassFromString(@"XCTestCase") == nil) {
-            exit(1);
-        }
-        return;
+        exit(1);
     }
 
     [self buildMenu];

--- a/easy-move-resize/EMRMoveResize.h
+++ b/easy-move-resize/EMRMoveResize.h
@@ -25,6 +25,7 @@ struct ResizeSection {
     CFTimeInterval _tracking;
     NSPoint _wndPosition;
     NSSize _wndSize;
+    BOOL _isResizing;
 }
 
 + (id) instance;
@@ -36,5 +37,6 @@ struct ResizeSection {
 @property CFTimeInterval tracking;
 @property NSPoint wndPosition;
 @property NSSize wndSize;
+@property BOOL isResizing;
 
 @end

--- a/easy-move-resize/EMRMoveResize.m
+++ b/easy-move-resize/EMRMoveResize.m
@@ -6,6 +6,7 @@
 @synthesize tracking = _tracking;
 @synthesize wndPosition = _wndPosition;
 @synthesize wndSize = _wndSize;
+@synthesize isResizing = _isResizing;
 
 + (EMRMoveResize*)instance {
     static EMRMoveResize *instance = nil;

--- a/easy-move-resize/EMRPreferences.h
+++ b/easy-move-resize/EMRPreferences.h
@@ -9,9 +9,13 @@
 #define EMRPreferences_h
 
 #define SHOULD_BRING_WINDOW_TO_FRONT @"BringToFront"
-#define SHOULD_MIDDLE_CLICK_RESIZE @"MiddleClickResize"
+#define SHOULD_MIDDLE_CLICK_RESIZE @"MiddleClickResize" // deprecated — used only for migration
 #define RESIZE_ONLY @"ResizeOnly"
 #define MODIFIER_FLAGS_DEFAULTS_KEY @"ModifierFlags"
+#define RESIZE_MODIFIER_FLAGS_DEFAULTS_KEY @"ResizeModifierFlags"
+#define MOVE_MOUSE_BUTTON @"MoveMouseButton"
+#define RESIZE_MOUSE_BUTTON @"ResizeMouseButton"
+#define PREFERENCES_VERSION_KEY @"PreferencesVersion"
 #define DISABLED_APPS_DEFAULTS_KEY @"DisabledApps"
 #define CTRL_KEY @"CTRL"
 #define SHIFT_KEY @"SHIFT"
@@ -20,25 +24,49 @@
 #define CMD_KEY @"CMD"
 #define FN_KEY @"FN"
 
+// Mouse button values
+enum {
+    EMRMouseButtonLeft = 0,
+    EMRMouseButtonRight = 1,
+    EMRMouseButtonMiddle = 2
+};
+
 @interface EMRPreferences : NSObject {
-    
+
 }
 
 @property (nonatomic) BOOL shouldBringWindowToFront;
-@property (nonatomic) BOOL shouldMiddleClickResize;
 @property (nonatomic) BOOL resizeOnly;
 
 // Initialize an EMRPreferences, persisting settings to the given userDefaults
 - (id)initWithUserDefaults:(NSUserDefaults *)defaults;
 
-// Get the modifier flags from the standard preferences
+// Get the move modifier flags from preferences
 - (int) modifierFlags;
 
-// Set or unset the given modifier key in the preferences
+// Set or unset the given move modifier key
 - (void) setModifierKey:(NSString*)singleFlagString enabled:(BOOL)enabled;
 
-// returns a set of the currently persisted key constants
+// returns a set of the currently persisted move key constants
 - (NSSet*) getFlagStringSet;
+
+// Get the resize modifier flags from preferences
+- (int) resizeModifierFlags;
+
+// Set or unset the given resize modifier key
+- (void) setResizeModifierKey:(NSString*)singleFlagString enabled:(BOOL)enabled;
+
+// returns a set of the currently persisted resize key constants
+- (NSSet*) getResizeFlagStringSet;
+
+// Mouse button preferences (EMRMouseButtonLeft/Right/Middle)
+- (int) moveMouseButton;
+- (void) setMoveMouseButton:(int)button;
+- (int) resizeMouseButton;
+- (void) setResizeMouseButton:(int)button;
+
+// Returns YES if move and resize have identical button + modifier config
+- (BOOL) hasConflictingConfig;
 
 // returns a dict of disabled apps
 - (NSDictionary*) getDisabledApps;

--- a/easy-move-resize/EMRPreferences.m
+++ b/easy-move-resize/EMRPreferences.m
@@ -1,6 +1,8 @@
 #import "EMRPreferences.h"
 
 #define DEFAULT_MODIFIER_FLAGS kCGEventFlagMaskCommand | kCGEventFlagMaskControl
+#define DEFAULT_RESIZE_MODIFIER_FLAGS kCGEventFlagMaskCommand | kCGEventFlagMaskControl
+#define CURRENT_PREFERENCES_VERSION 2
 
 @implementation EMRPreferences {
 @private
@@ -29,29 +31,41 @@
             if (disabledApps == nil) {
                 [userDefaults setObject:[NSDictionary dictionary] forKey:DISABLED_APPS_DEFAULTS_KEY];
             }
+
+            // Version-gated migration from v1 preferences
+            NSInteger version = [userDefaults integerForKey:PREFERENCES_VERSION_KEY];
+            if (version < CURRENT_PREFERENCES_VERSION) {
+                // Migrate MiddleClickResize → ResizeMouseButton
+                if ([userDefaults boolForKey:SHOULD_MIDDLE_CLICK_RESIZE]) {
+                    [userDefaults setInteger:EMRMouseButtonMiddle forKey:RESIZE_MOUSE_BUTTON];
+                }
+                // Copy existing ModifierFlags as resize modifiers (preserves current behavior
+                // where both operations use the same modifier set)
+                NSString *existingFlags = [userDefaults stringForKey:MODIFIER_FLAGS_DEFAULTS_KEY];
+                if (existingFlags != nil) {
+                    [userDefaults setObject:existingFlags forKey:RESIZE_MODIFIER_FLAGS_DEFAULTS_KEY];
+                }
+                [userDefaults setInteger:CURRENT_PREFERENCES_VERSION forKey:PREFERENCES_VERSION_KEY];
+            }
         }
     }
     return self;
 }
 
+#pragma mark - Move modifier flags
+
 - (int)modifierFlags {
-    int modifierFlags = 0;
-    
     NSString *modifierFlagString = [userDefaults stringForKey:MODIFIER_FLAGS_DEFAULTS_KEY];
     if (modifierFlagString == nil) {
         return DEFAULT_MODIFIER_FLAGS;
     }
-    
-    modifierFlags = [self flagsFromFlagString:modifierFlagString];
-    
-    return modifierFlags;
+    return [self flagsFromFlagString:modifierFlagString];
 }
 
 - (void)setModifierFlagString:(NSString *)flagString {
     flagString = [[flagString stringByReplacingOccurrencesOfString:@" " withString:@""] uppercaseString];
     [userDefaults setObject:flagString forKey:MODIFIER_FLAGS_DEFAULTS_KEY];
 }
-
 
 - (void)setModifierKey:(NSString *)singleFlagString enabled:(BOOL)enabled {
     singleFlagString = [singleFlagString uppercaseString];
@@ -80,6 +94,80 @@
     return flagSet;
 }
 
+#pragma mark - Resize modifier flags
+
+- (int)resizeModifierFlags {
+    NSString *flagString = [userDefaults stringForKey:RESIZE_MODIFIER_FLAGS_DEFAULTS_KEY];
+    if (flagString == nil) {
+        return DEFAULT_RESIZE_MODIFIER_FLAGS;
+    }
+    return [self flagsFromFlagString:flagString];
+}
+
+- (void)setResizeModifierFlagString:(NSString *)flagString {
+    flagString = [[flagString stringByReplacingOccurrencesOfString:@" " withString:@""] uppercaseString];
+    [userDefaults setObject:flagString forKey:RESIZE_MODIFIER_FLAGS_DEFAULTS_KEY];
+}
+
+- (void)setResizeModifierKey:(NSString *)singleFlagString enabled:(BOOL)enabled {
+    singleFlagString = [singleFlagString uppercaseString];
+    NSString *flagString = [userDefaults stringForKey:RESIZE_MODIFIER_FLAGS_DEFAULTS_KEY];
+    if (flagString == nil) {
+        NSLog(@"Unexpected null for resize modifier flags");
+        flagString = [@[CTRL_KEY, CMD_KEY] componentsJoinedByString:@","];
+    }
+    NSMutableSet *flagSet = [self createSetFromFlagString:flagString];
+    if (enabled) {
+        [flagSet addObject:singleFlagString];
+    }
+    else {
+        [flagSet removeObject:singleFlagString];
+    }
+    [self setResizeModifierFlagString:[[flagSet allObjects] componentsJoinedByString:@","]];
+}
+
+- (NSSet*)getResizeFlagStringSet {
+    NSString *flagString = [userDefaults stringForKey:RESIZE_MODIFIER_FLAGS_DEFAULTS_KEY];
+    if (flagString == nil) {
+        NSLog(@"Unexpected null for resize modifier flags");
+        flagString = [@[CTRL_KEY, CMD_KEY] componentsJoinedByString:@","];
+    }
+    return [self createSetFromFlagString:flagString];
+}
+
+#pragma mark - Mouse button preferences
+
+- (int)moveMouseButton {
+    // Default: Left (0). NSUserDefaults returns 0 for unset integer keys,
+    // which conveniently matches EMRMouseButtonLeft.
+    return (int)[userDefaults integerForKey:MOVE_MOUSE_BUTTON];
+}
+
+- (void)setMoveMouseButton:(int)button {
+    [userDefaults setInteger:button forKey:MOVE_MOUSE_BUTTON];
+}
+
+- (int)resizeMouseButton {
+    // Default: Right (1). We can't rely on 0-default here, so check if key exists.
+    if ([userDefaults objectForKey:RESIZE_MOUSE_BUTTON] == nil) {
+        return EMRMouseButtonRight;
+    }
+    return (int)[userDefaults integerForKey:RESIZE_MOUSE_BUTTON];
+}
+
+- (void)setResizeMouseButton:(int)button {
+    [userDefaults setInteger:button forKey:RESIZE_MOUSE_BUTTON];
+}
+
+#pragma mark - Conflict validation
+
+- (BOOL)hasConflictingConfig {
+    if ([self moveMouseButton] != [self resizeMouseButton]) return NO;
+    return [self modifierFlags] == [self resizeModifierFlags];
+}
+
+#pragma mark - Disabled apps
+
 - (NSDictionary*) getDisabledApps {
     return [userDefaults dictionaryForKey:DISABLED_APPS_DEFAULTS_KEY];
 }
@@ -94,13 +182,20 @@
     [userDefaults setObject:disabledApps forKey:DISABLED_APPS_DEFAULTS_KEY];
 }
 
+#pragma mark - Defaults
+
 - (void)setToDefaults {
     [self setModifierFlagString:[@[CTRL_KEY, CMD_KEY] componentsJoinedByString:@","]];
+    [self setResizeModifierFlagString:[@[CTRL_KEY, CMD_KEY] componentsJoinedByString:@","]];
     [userDefaults setBool:NO forKey:SHOULD_BRING_WINDOW_TO_FRONT];
-    [userDefaults setBool:NO forKey:SHOULD_MIDDLE_CLICK_RESIZE];
     [userDefaults setBool:NO forKey:RESIZE_ONLY];
+    [userDefaults setInteger:EMRMouseButtonLeft forKey:MOVE_MOUSE_BUTTON];
+    [userDefaults setInteger:EMRMouseButtonRight forKey:RESIZE_MOUSE_BUTTON];
+    [userDefaults setInteger:CURRENT_PREFERENCES_VERSION forKey:PREFERENCES_VERSION_KEY];
     [userDefaults setObject:[NSDictionary dictionary] forKey:DISABLED_APPS_DEFAULTS_KEY];
 }
+
+#pragma mark - Flag string utilities
 
 - (NSMutableSet*)createSetFromFlagString:(NSString*)modifierFlagString {
     modifierFlagString = [[modifierFlagString stringByReplacingOccurrencesOfString:@" " withString:@""] uppercaseString];
@@ -118,7 +213,7 @@
         return 0;
     }
     NSSet *flagList = [self createSetFromFlagString:modifierFlagString];
-    
+
     if ([flagList containsObject:CTRL_KEY]) {
         modifierFlags |= kCGEventFlagMaskControl;
     }
@@ -137,22 +232,17 @@
     if ([flagList containsObject:FN_KEY]) {
         modifierFlags |= kCGEventFlagMaskSecondaryFn;
     }
-    
+
     return modifierFlags;
 }
+
+#pragma mark - Boolean preferences
 
 -(BOOL)shouldBringWindowToFront {
     return [userDefaults boolForKey:SHOULD_BRING_WINDOW_TO_FRONT];
 }
 -(void)setShouldBringWindowToFront:(BOOL)bringToFront {
     [userDefaults setBool:bringToFront forKey:SHOULD_BRING_WINDOW_TO_FRONT];
-}
-
--(BOOL)shouldMiddleClickResize {
-    return [userDefaults boolForKey:SHOULD_MIDDLE_CLICK_RESIZE];
-}
--(void)setShouldMiddleClickResize:(BOOL)middleClickResize {
-    [userDefaults setBool:middleClickResize forKey:SHOULD_MIDDLE_CLICK_RESIZE];
 }
 
 -(BOOL)resizeOnly {
@@ -163,4 +253,3 @@
 }
 
 @end
-

--- a/easy-move-resize/en.lproj/MainMenu.xib
+++ b/easy-move-resize/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -659,47 +659,10 @@
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="a5T-MQ-31B"/>
-                <menuItem title="Alt" id="toO-ef-6Sa">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="modifierToggle:" target="494" id="gvG-0m-DpJ"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Cmd" id="yMO-nW-fjN">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="modifierToggle:" target="494" id="HrM-v0-sYh"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Ctrl" id="cOd-3Z-1Py">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="modifierToggle:" target="494" id="niS-3l-sN2"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Shift" id="SZL-bI-dng">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="modifierToggle:" target="494" id="tw0-HJ-yQk"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Fn" id="3Up-j9-Hdf">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="modifierToggle:" target="494" id="ENl-Hk-exg"/>
-                    </connections>
-                </menuItem>
-                <menuItem isSeparatorItem="YES" id="CnB-BD-kwb"/>
                 <menuItem title="Bring Window to Front" id="gtC-wv-5bN">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="toggleBringWindowToFront:" target="494" id="utG-yc-4A0"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Middle Click resize" id="S2R-bI-Azo">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="toggleMiddleClickResize:" target="494" id="gAe-qW-XIr"/>
                     </connections>
                 </menuItem>
                 <menuItem title="Resize only" id="ErU-VJ-PWr">
@@ -738,17 +701,11 @@
         </menu>
         <customObject id="494" customClass="EMRAppDelegate">
             <connections>
-                <outlet property="altMenu" destination="toO-ef-6Sa" id="nQz-2m-M8b"/>
                 <outlet property="bringWindowFrontMenu" destination="gtC-wv-5bN" id="TDw-e0-RDR"/>
-                <outlet property="cmdMenu" destination="yMO-nW-fjN" id="TRT-4a-jj5"/>
-                <outlet property="ctrlMenu" destination="cOd-3Z-1Py" id="mtX-4X-qya"/>
                 <outlet property="disabledAppsMenu" destination="trL-IE-A9o" id="a5e-LQ-P3b"/>
                 <outlet property="disabledMenu" destination="Q0w-G0-Ppy" id="D3v-HP-HjG"/>
-                <outlet property="fnMenu" destination="3Up-j9-Hdf" id="ans-jZ-8mN"/>
                 <outlet property="lastAppMenu" destination="ZKn-HI-Yq4" id="aO7-eG-bLr"/>
-                <outlet property="middleClickResizeMenu" destination="S2R-bI-Azo" id="c8V-7R-1QY"/>
                 <outlet property="resizeOnlyMenu" destination="ErU-VJ-PWr" id="eXx-DE-rHT"/>
-                <outlet property="shiftMenu" destination="SZL-bI-dng" id="YZk-pM-c3k"/>
                 <outlet property="statusMenu" destination="obP-gH-pam" id="YfI-Jt-Lpf"/>
             </connections>
         </customObject>

--- a/easy-move-resizeTests/EMRAppDelegateTest.m
+++ b/easy-move-resizeTests/EMRAppDelegateTest.m
@@ -1,0 +1,506 @@
+#import <XCTest/XCTest.h>
+#import "EMRAppDelegate.h"
+#import "EMRPreferences.h"
+#import "EMRMoveResize.h"
+
+// The callback is a C function with external linkage in EMRAppDelegate.m
+extern CGEventRef myCGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon);
+
+// Expose refreshCachedPreferences and private ivars for testing via category
+@interface EMRAppDelegate (Testing)
+- (void)refreshCachedPreferences;
+- (BOOL)resizeOnly;
+@end
+
+@interface EMRAppDelegateTest : XCTestCase
+
+@end
+
+@implementation EMRAppDelegateTest {
+    EMRAppDelegate *delegate;
+}
+
+- (void)setUp {
+    [super setUp];
+    delegate = [[EMRAppDelegate alloc] init];
+    // Reset EMRMoveResize singleton state
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    [mr setTracking:0];
+    [mr setIsResizing:NO];
+    [mr setWindow:nil];
+}
+
+#pragma mark - Helper: set cached ivars directly via KVC
+
+- (void)setCachedMoveModifiers:(int)flags {
+    [delegate setValue:@(flags) forKey:@"keyModifierFlags"];
+}
+- (void)setCachedResizeModifiers:(int)flags {
+    [delegate setValue:@(flags) forKey:@"resizeKeyModifierFlags"];
+}
+- (void)setCachedMoveButton:(int)btn {
+    [delegate setValue:@(btn) forKey:@"cachedMoveMouseButton"];
+}
+- (void)setCachedResizeButton:(int)btn {
+    [delegate setValue:@(btn) forKey:@"cachedResizeMouseButton"];
+}
+- (void)setCachedHasConflict:(BOOL)conflict {
+    [delegate setValue:@(conflict) forKey:@"cachedHasConflict"];
+}
+
+#pragma mark - Helper: create a CGEvent with specific type and modifier flags
+
+- (CGEventRef)createMouseEvent:(CGEventType)type flags:(CGEventFlags)flags {
+    // Create a mouse event at position (100, 100)
+    CGPoint location = CGPointMake(100, 100);
+
+    // Map CGEventType to CGMouseButton
+    CGMouseButton button = kCGMouseButtonLeft;
+    if (type == kCGEventRightMouseDown || type == kCGEventRightMouseDragged || type == kCGEventRightMouseUp) {
+        button = kCGMouseButtonRight;
+    } else if (type == kCGEventOtherMouseDown || type == kCGEventOtherMouseDragged || type == kCGEventOtherMouseUp) {
+        button = kCGMouseButtonCenter;
+    }
+
+    CGEventRef event = CGEventCreateMouseEvent(NULL, type, location, button);
+    if (event && flags != 0) {
+        CGEventSetFlags(event, flags);
+    }
+    return event;
+}
+
+#pragma mark - refreshCachedPreferences
+
+- (void)testRefreshCachedPreferencesUpdatesAccessors {
+    // The delegate uses the "userPrefs" suite which may have leftover state.
+    // Reset to known defaults first, then verify cache sync.
+    NSUserDefaults *prefs = [[NSUserDefaults alloc] initWithSuiteName:@"userPrefs"];
+    [prefs setObject:@"CTRL,CMD" forKey:@"ModifierFlags"];
+    [prefs setObject:@"CTRL,CMD" forKey:@"ResizeModifierFlags"];
+    [prefs setInteger:EMRMouseButtonLeft forKey:@"MoveMouseButton"];
+    [prefs setInteger:EMRMouseButtonRight forKey:@"ResizeMouseButton"];
+
+    [delegate refreshCachedPreferences];
+
+    int expectedFlags = kCGEventFlagMaskCommand | kCGEventFlagMaskControl;
+    XCTAssertEqual([delegate modifierFlags], expectedFlags, "Cached move modifiers should match preferences");
+    XCTAssertEqual([delegate resizeModifierFlags], expectedFlags, "Cached resize modifiers should match preferences");
+    XCTAssertEqual([delegate moveMouseButton], EMRMouseButtonLeft, "Cached move button should match preferences");
+    XCTAssertEqual([delegate resizeMouseButton], EMRMouseButtonRight, "Cached resize button should match preferences");
+
+    // Now change preferences and refresh — verify update
+    [prefs setObject:@"CMD,ALT" forKey:@"ResizeModifierFlags"];
+    [prefs setInteger:EMRMouseButtonMiddle forKey:@"ResizeMouseButton"];
+
+    [delegate refreshCachedPreferences];
+
+    int expectedResizeFlags = kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate;
+    XCTAssertEqual([delegate resizeModifierFlags], expectedResizeFlags, "Cached resize modifiers should update after preference change");
+    XCTAssertEqual([delegate resizeMouseButton], EMRMouseButtonMiddle, "Cached resize button should update after preference change");
+
+    // Restore defaults to not pollute other tests
+    [prefs setObject:@"CTRL,CMD" forKey:@"ModifierFlags"];
+    [prefs setObject:@"CTRL,CMD" forKey:@"ResizeModifierFlags"];
+    [prefs setInteger:EMRMouseButtonLeft forKey:@"MoveMouseButton"];
+    [prefs setInteger:EMRMouseButtonRight forKey:@"ResizeMouseButton"];
+}
+
+#pragma mark - Accessor methods return cached ivars
+
+- (void)testModifierFlagsReturnsCachedValue {
+    [self setCachedMoveModifiers:42];
+    XCTAssertEqual([delegate modifierFlags], 42);
+}
+
+- (void)testResizeModifierFlagsReturnsCachedValue {
+    [self setCachedResizeModifiers:99];
+    XCTAssertEqual([delegate resizeModifierFlags], 99);
+}
+
+- (void)testMoveMouseButtonReturnsCachedValue {
+    [self setCachedMoveButton:EMRMouseButtonMiddle];
+    XCTAssertEqual([delegate moveMouseButton], EMRMouseButtonMiddle);
+}
+
+- (void)testResizeMouseButtonReturnsCachedValue {
+    [self setCachedResizeButton:EMRMouseButtonLeft];
+    XCTAssertEqual([delegate resizeMouseButton], EMRMouseButtonLeft);
+}
+
+#pragma mark - Callback: session inactive passes through
+
+- (void)testCallbackPassesThroughWhenSessionInactive {
+    [delegate setSessionActive:NO];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseDown
+                                        flags:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventLeftMouseDown, event, (__bridge void *)delegate);
+    XCTAssertEqual(result, event, "Callback should pass through when session is inactive");
+    CFRelease(event);
+}
+
+#pragma mark - Callback: both modifiers zero → early return
+
+- (void)testCallbackPassesThroughWhenBothModifiersZero {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:0];
+    [self setCachedResizeModifiers:0];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonRight];
+
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseDown flags:0];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventLeftMouseDown, event, (__bridge void *)delegate);
+    XCTAssertEqual(result, event, "Callback should pass through when both modifier sets are zero");
+    CFRelease(event);
+}
+
+#pragma mark - Callback: wrong modifiers → pass through
+
+- (void)testCallbackPassesThroughWithWrongModifiers {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonRight];
+
+    // Send left-click with only Shift — matches neither move nor resize
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseDown flags:kCGEventFlagMaskShift];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventLeftMouseDown, event, (__bridge void *)delegate);
+    XCTAssertEqual(result, event, "Callback should pass through with non-matching modifiers");
+    CFRelease(event);
+}
+
+#pragma mark - Callback: wrong button → pass through
+
+- (void)testCallbackPassesThroughWithWrongButton {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonRight];
+
+    // Send middle-click with correct modifiers — neither move (Left) nor resize (Right)
+    CGEventFlags flags = kCGEventFlagMaskCommand | kCGEventFlagMaskControl;
+    CGEventRef event = [self createMouseEvent:kCGEventOtherMouseDown flags:flags];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventOtherMouseDown, event, (__bridge void *)delegate);
+    XCTAssertEqual(result, event, "Callback should pass through when button doesn't match move or resize");
+    CFRelease(event);
+}
+
+#pragma mark - Callback: extra modifiers → pass through
+
+- (void)testCallbackPassesThroughWithExtraModifiers {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonLeft];
+
+    // Send left-click with Cmd+Ctrl+Alt — has extras for both sets
+    CGEventFlags flags = kCGEventFlagMaskCommand | kCGEventFlagMaskControl | kCGEventFlagMaskAlternate;
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseDown flags:flags];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventLeftMouseDown, event, (__bridge void *)delegate);
+    XCTAssertEqual(result, event, "Callback should pass through when extra modifiers are held for both sets");
+    CFRelease(event);
+}
+
+#pragma mark - Callback: resizeOnly suppresses move
+
+- (void)testCallbackPassesThroughMoveWhenResizeOnly {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonRight];
+
+    // Set resizeOnly via preferences (the callback reads it via [ourDelegate resizeOnly])
+    // The delegate's init creates its own preferences, so we need to use KVC or the accessor
+    // Actually, resizeOnly is read from preferences, not cached. Let me check...
+    // The callback calls: bool resizeOnly = [ourDelegate resizeOnly];
+    // which calls: [preferences resizeOnly] which reads from NSUserDefaults "userPrefs"
+
+    // We can use the delegate's own preferences by writing to the "userPrefs" suite
+    NSUserDefaults *prefs = [[NSUserDefaults alloc] initWithSuiteName:@"userPrefs"];
+    [prefs setBool:YES forKey:@"ResizeOnly"];
+
+    CGEventFlags flags = kCGEventFlagMaskCommand | kCGEventFlagMaskControl;
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseDown flags:flags];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventLeftMouseDown, event, (__bridge void *)delegate);
+    XCTAssertEqual(result, event, "Move event should pass through when resizeOnly is ON");
+
+    // Clean up
+    [prefs setBool:NO forKey:@"ResizeOnly"];
+    CFRelease(event);
+}
+
+#pragma mark - Callback: mouse-up clears tracking and isResizing
+
+- (void)testMouseUpClearsTrackingAndIsResizing {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonRight];
+
+    // Simulate an active tracking session (as if mouse-down already happened)
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    [mr setTracking:CACurrentMediaTime()];
+    [mr setIsResizing:YES];
+
+    XCTAssertTrue([mr tracking] > 0, "Precondition: tracking should be active");
+    XCTAssertTrue([mr isResizing], "Precondition: isResizing should be YES");
+
+    // Send mouse-up (left button) — the button/modifiers don't need to match for up events
+    // as long as tracking > 0
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseUp flags:0];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventLeftMouseUp, event, (__bridge void *)delegate);
+
+    XCTAssertTrue(result == NULL, "Mouse-up during tracking should be handled (return NULL)");
+    XCTAssertEqual([mr tracking], 0, "tracking should be cleared after mouse-up");
+    XCTAssertFalse([mr isResizing], "isResizing should be NO after mouse-up");
+    CFRelease(event);
+}
+
+- (void)testRightMouseUpClearsTrackingAndIsResizing {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonRight];
+
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    [mr setTracking:CACurrentMediaTime()];
+    [mr setIsResizing:YES];
+
+    CGEventRef event = [self createMouseEvent:kCGEventRightMouseUp flags:0];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventRightMouseUp, event, (__bridge void *)delegate);
+
+    XCTAssertTrue(result == NULL, "Right mouse-up during tracking should be handled");
+    XCTAssertEqual([mr tracking], 0);
+    XCTAssertFalse([mr isResizing]);
+    CFRelease(event);
+}
+
+#pragma mark - Callback: mouse-up with no active tracking → pass through
+
+- (void)testMouseUpWithNoTrackingPassesThrough {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonRight];
+
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    [mr setTracking:0]; // No active tracking
+
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseUp flags:0];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventLeftMouseUp, event, (__bridge void *)delegate);
+    XCTAssertEqual(result, event, "Mouse-up with no active tracking should pass through");
+    CFRelease(event);
+}
+
+#pragma mark - Callback: unrecognized event type → pass through
+
+- (void)testCallbackPassesThroughUnrecognizedEventType {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonRight];
+
+    // Create a scroll wheel event (not handled by the callback)
+    CGEventRef event = CGEventCreateScrollWheelEvent(NULL, kCGScrollEventUnitLine, 1, 1);
+    CGEventRef result = myCGEventCallback(NULL, kCGEventScrollWheel, event, (__bridge void *)delegate);
+    XCTAssertEqual(result, event, "Scroll wheel events should pass through");
+    CFRelease(event);
+}
+
+#pragma mark - Callback: event tap re-enable
+
+- (void)testCallbackReEnablesEventTapOnTimeout {
+    // The callback should re-enable the event tap when receiving kCGEventTapDisabledByTimeout
+    // We can't fully test this without a real event tap, but we can verify it doesn't crash
+    // and returns the event
+    CGEventRef event = CGEventCreate(NULL);
+    CGEventRef result = myCGEventCallback(NULL, kCGEventTapDisabledByTimeout, event, (__bridge void *)delegate);
+    XCTAssertEqual(result, event, "Should return event after re-enabling tap");
+    CFRelease(event);
+}
+
+#pragma mark - Callback: conflict resolution (both match → resize wins)
+
+- (void)testConflictResolutionResizeWins {
+    [delegate setSessionActive:YES];
+    // Configure: same button (Left) + same modifiers for both operations
+    int flags = kCGEventFlagMaskCommand | kCGEventFlagMaskControl;
+    [self setCachedMoveModifiers:flags];
+    [self setCachedResizeModifiers:flags];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonLeft];
+    [self setCachedHasConflict:YES];
+
+    // Send mouse-down with matching modifiers.
+    // Both move and resize match → conflict resolution should pick resize.
+    // The callback enters the resize path (isForResize=YES), which tries to get window size
+    // via AX. In test environment with no real window, the AX size query fails and the callback
+    // clears tracking+isResizing and returns NULL.
+    //
+    // Key verification: if move had been chosen instead, the callback would NOT enter the
+    // resize size-query path, so tracking would remain active and isResizing would be NO.
+    // By checking that tracking is 0 (resize path's AX failure cleanup ran), we confirm
+    // the callback chose the resize path, proving conflict resolution chose resize.
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseDown flags:flags];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventLeftMouseDown, event, (__bridge void *)delegate);
+
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    // The resize path was entered (AX size query ran and failed, clearing tracking)
+    // If move had been chosen, tracking would still be > 0 (move path doesn't query size)
+    XCTAssertTrue(result == NULL, "Conflicting event should be consumed (not passed through)");
+    XCTAssertEqual([mr tracking], 0, "Resize path AX failure should have cleared tracking, confirming resize was chosen over move");
+
+    [mr setIsResizing:NO];
+    CFRelease(event);
+}
+
+#pragma mark - Callback: independent modifier matching
+
+- (void)testMoveModifiersMatchResizeModifiersDont {
+    [delegate setSessionActive:YES];
+    // Move: Cmd+Ctrl on Left, Resize: Cmd+Alt on Left
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonLeft];
+
+    // Send left-click with Cmd+Ctrl — should match move only
+    CGEventFlags moveFlags = kCGEventFlagMaskCommand | kCGEventFlagMaskControl;
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseDown flags:moveFlags];
+    myCGEventCallback(NULL, kCGEventLeftMouseDown, event, (__bridge void *)delegate);
+
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    // Move matched, resize didn't → isResizing should be NO
+    XCTAssertFalse([mr isResizing], "Move modifiers should match but resize should not — isResizing should be NO");
+
+    [mr setTracking:0];
+    [mr setIsResizing:NO];
+    CFRelease(event);
+}
+
+- (void)testResizeModifiersMatchMoveModifiersDont {
+    [delegate setSessionActive:YES];
+    // Move: Cmd+Ctrl on Left, Resize: Cmd+Alt on Left
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonLeft];
+
+    // Send left-click with Cmd+Alt — should match resize only
+    CGEventFlags resizeFlags = kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate;
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseDown flags:resizeFlags];
+    myCGEventCallback(NULL, kCGEventLeftMouseDown, event, (__bridge void *)delegate);
+
+    // The resize path was entered (AX size query runs and fails in test env, clearing tracking).
+    // If no match had occurred, tracking would remain 0 from setUp and the event would pass through.
+    // By verifying the event was consumed (NULL return) and tracking is 0 (resize path cleanup),
+    // we confirm the resize modifiers matched.
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    XCTAssertEqual([mr tracking], 0, "Resize path AX failure should have cleared tracking, confirming resize modifiers matched");
+
+    [mr setIsResizing:NO];
+    CFRelease(event);
+}
+
+#pragma mark - Callback: drag during active tracking respects isResizing
+
+- (void)testDragDuringMoveTrackingDoesNotSetIsResizing {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonRight];
+
+    // Simulate active move tracking
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    [mr setTracking:CACurrentMediaTime()];
+    [mr setIsResizing:NO];
+    [mr setWndPosition:NSMakePoint(100, 100)];
+
+    // Send drag event — during active tracking, the drag handler should fire
+    CGEventFlags flags = kCGEventFlagMaskCommand | kCGEventFlagMaskControl;
+    CGEventRef event = [self createMouseEvent:kCGEventLeftMouseDragged flags:flags];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventLeftMouseDragged, event, (__bridge void *)delegate);
+
+    // Drag during move tracking: isResizing should still be NO
+    XCTAssertFalse([mr isResizing], "isResizing should remain NO during move drag");
+    // The drag was handled (but AX calls to move window may fail in test — that's OK)
+    // If window is nil, the AX call is a no-op but doesn't crash
+    XCTAssertTrue(result == NULL, "Drag during active tracking should be handled (return NULL)");
+
+    [mr setTracking:0];
+    CFRelease(event);
+}
+
+- (void)testDragDuringResizeTrackingKeepsIsResizing {
+    [delegate setSessionActive:YES];
+    [self setCachedMoveModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskControl];
+    [self setCachedResizeModifiers:kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonRight];
+
+    // Simulate active resize tracking
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    [mr setTracking:CACurrentMediaTime()];
+    [mr setIsResizing:YES];
+    [mr setWndPosition:NSMakePoint(100, 100)];
+    [mr setWndSize:NSMakeSize(400, 300)];
+    struct ResizeSection section = { .xResizeDirection = right, .yResizeDirection = bottom };
+    [mr setResizeSection:section];
+
+    CGEventFlags flags = kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate;
+    CGEventRef event = [self createMouseEvent:kCGEventRightMouseDragged flags:flags];
+    CGEventRef result = myCGEventCallback(NULL, kCGEventRightMouseDragged, event, (__bridge void *)delegate);
+
+    XCTAssertTrue([mr isResizing], "isResizing should remain YES during resize drag");
+    XCTAssertTrue(result == NULL, "Drag during active tracking should be handled");
+
+    [mr setTracking:0];
+    [mr setIsResizing:NO];
+    CFRelease(event);
+}
+
+#pragma mark - Callback: different button configurations
+
+- (void)testMiddleClickResizeConfiguration {
+    [delegate setSessionActive:YES];
+    int flags = kCGEventFlagMaskCommand | kCGEventFlagMaskControl;
+    [self setCachedMoveModifiers:flags];
+    [self setCachedResizeModifiers:flags];
+    [self setCachedMoveButton:EMRMouseButtonLeft];
+    [self setCachedResizeButton:EMRMouseButtonMiddle]; // Middle-click resize
+
+    // Left-click should match move, not resize
+    CGEventRef leftEvent = [self createMouseEvent:kCGEventLeftMouseDown flags:flags];
+    myCGEventCallback(NULL, kCGEventLeftMouseDown, leftEvent, (__bridge void *)delegate);
+
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    XCTAssertFalse([mr isResizing], "Left-click should match move (not resize) when resize is middle-click");
+
+    [mr setTracking:0];
+    [mr setIsResizing:NO];
+
+    // Middle-click should match resize.
+    // The resize path enters AX size query which fails in test env, clearing tracking.
+    // We confirm the resize path was chosen by checking tracking == 0 (cleanup ran).
+    CGEventRef middleEvent = [self createMouseEvent:kCGEventOtherMouseDown flags:flags];
+    myCGEventCallback(NULL, kCGEventOtherMouseDown, middleEvent, (__bridge void *)delegate);
+
+    XCTAssertEqual([mr tracking], 0, "Resize path AX failure should have cleared tracking, confirming middle-click matched resize");
+
+    [mr setIsResizing:NO];
+    CFRelease(leftEvent);
+    CFRelease(middleEvent);
+}
+
+@end

--- a/easy-move-resizeTests/EMRAppDelegateTest.m
+++ b/easy-move-resizeTests/EMRAppDelegateTest.m
@@ -317,17 +317,9 @@ extern CGEventRef myCGEventCallback(CGEventTapProxy proxy, CGEventType type, CGE
     CFRelease(event);
 }
 
-#pragma mark - Callback: event tap re-enable
-
-- (void)testCallbackReEnablesEventTapOnTimeout {
-    // The callback should re-enable the event tap when receiving kCGEventTapDisabledByTimeout
-    // We can't fully test this without a real event tap, but we can verify it doesn't crash
-    // and returns the event
-    CGEventRef event = CGEventCreate(NULL);
-    CGEventRef result = myCGEventCallback(NULL, kCGEventTapDisabledByTimeout, event, (__bridge void *)delegate);
-    XCTAssertEqual(result, event, "Should return event after re-enabling tap");
-    CFRelease(event);
-}
+// Note: kCGEventTapDisabledByTimeout handling cannot be tested without a real event tap,
+// as the callback calls CGEventTapEnable([EMRMoveResize instance].eventTap, true)
+// which crashes on a NULL event tap reference.
 
 #pragma mark - Callback: conflict resolution (both match → resize wins)
 
@@ -396,17 +388,17 @@ extern CGEventRef myCGEventCallback(CGEventTapProxy proxy, CGEventType type, CGE
     [self setCachedMoveButton:EMRMouseButtonLeft];
     [self setCachedResizeButton:EMRMouseButtonLeft];
 
-    // Send left-click with Cmd+Alt — should match resize only
+    // Send left-click with Cmd+Alt — should match resize only.
+    // In test env: resize path enters AX size query which fails on NULL window,
+    // clearing tracking to 0 and returning NULL. This confirms the resize path was chosen.
+    // (If move had been chosen, tracking would remain > 0 since move doesn't query size.)
     CGEventFlags resizeFlags = kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate;
     CGEventRef event = [self createMouseEvent:kCGEventLeftMouseDown flags:resizeFlags];
-    myCGEventCallback(NULL, kCGEventLeftMouseDown, event, (__bridge void *)delegate);
+    CGEventRef result = myCGEventCallback(NULL, kCGEventLeftMouseDown, event, (__bridge void *)delegate);
 
-    // The resize path was entered (AX size query runs and fails in test env, clearing tracking).
-    // If no match had occurred, tracking would remain 0 from setUp and the event would pass through.
-    // By verifying the event was consumed (NULL return) and tracking is 0 (resize path cleanup),
-    // we confirm the resize modifiers matched.
     EMRMoveResize *mr = [EMRMoveResize instance];
-    XCTAssertEqual([mr tracking], 0, "Resize path AX failure should have cleared tracking, confirming resize modifiers matched");
+    XCTAssertTrue(result == NULL, "Resize-matching event should be consumed (not passed through)");
+    XCTAssertEqual([mr tracking], 0, "Resize path AX failure clears tracking, confirming resize was chosen");
 
     [mr setIsResizing:NO];
     CFRelease(event);
@@ -492,11 +484,12 @@ extern CGEventRef myCGEventCallback(CGEventTapProxy proxy, CGEventType type, CGE
 
     // Middle-click should match resize.
     // The resize path enters AX size query which fails in test env, clearing tracking.
-    // We confirm the resize path was chosen by checking tracking == 0 (cleanup ran).
+    // We confirm the resize path was chosen by checking return value is NULL and tracking == 0.
     CGEventRef middleEvent = [self createMouseEvent:kCGEventOtherMouseDown flags:flags];
-    myCGEventCallback(NULL, kCGEventOtherMouseDown, middleEvent, (__bridge void *)delegate);
+    CGEventRef middleResult = myCGEventCallback(NULL, kCGEventOtherMouseDown, middleEvent, (__bridge void *)delegate);
 
-    XCTAssertEqual([mr tracking], 0, "Resize path AX failure should have cleared tracking, confirming middle-click matched resize");
+    XCTAssertTrue(middleResult == NULL, "Middle-click resize event should be consumed");
+    XCTAssertEqual([mr tracking], 0, "Resize path AX failure clears tracking, confirming middle-click matched resize");
 
     [mr setIsResizing:NO];
     CFRelease(leftEvent);

--- a/easy-move-resizeTests/EMRMoveResizeTest.m
+++ b/easy-move-resizeTests/EMRMoveResizeTest.m
@@ -1,0 +1,165 @@
+#import <XCTest/XCTest.h>
+#import "EMRMoveResize.h"
+
+@interface EMRMoveResizeTest : XCTestCase
+
+@end
+
+@implementation EMRMoveResizeTest
+
+- (void)setUp {
+    [super setUp];
+    // Reset state before each test
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    [mr setTracking:0];
+    [mr setIsResizing:NO];
+    [mr setWindow:nil];
+}
+
+#pragma mark - Singleton
+
+- (void)testInstanceReturnsSameObject {
+    EMRMoveResize *a = [EMRMoveResize instance];
+    EMRMoveResize *b = [EMRMoveResize instance];
+    XCTAssertEqual(a, b, "instance should return the same singleton object");
+}
+
+- (void)testInstanceIsNotNil {
+    XCTAssertNotNil([EMRMoveResize instance], "instance should never return nil");
+}
+
+#pragma mark - isResizing property
+
+- (void)testIsResizingDefaultsToNO {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    XCTAssertFalse([mr isResizing], "isResizing should default to NO after reset");
+}
+
+- (void)testSetIsResizingToYES {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    [mr setIsResizing:YES];
+    XCTAssertTrue([mr isResizing], "isResizing should be YES after setting to YES");
+}
+
+- (void)testSetIsResizingBackToNO {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    [mr setIsResizing:YES];
+    [mr setIsResizing:NO];
+    XCTAssertFalse([mr isResizing], "isResizing should be NO after setting back to NO");
+}
+
+#pragma mark - tracking property
+
+- (void)testTrackingDefaultsToZero {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    XCTAssertEqual([mr tracking], 0, "tracking should be 0 after reset");
+}
+
+- (void)testSetTracking {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    CFTimeInterval now = CACurrentMediaTime();
+    [mr setTracking:now];
+    XCTAssertEqual([mr tracking], now, "tracking should store the time value");
+}
+
+- (void)testClearTracking {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    [mr setTracking:CACurrentMediaTime()];
+    [mr setTracking:0];
+    XCTAssertEqual([mr tracking], 0, "tracking should be 0 after clearing");
+}
+
+#pragma mark - resizeSection struct
+
+- (void)testResizeSectionStorage {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    struct ResizeSection section;
+    section.xResizeDirection = left;
+    section.yResizeDirection = top;
+    [mr setResizeSection:section];
+
+    struct ResizeSection retrieved = [mr resizeSection];
+    XCTAssertEqual(retrieved.xResizeDirection, left, "xResizeDirection should be left");
+    XCTAssertEqual(retrieved.yResizeDirection, top, "yResizeDirection should be top");
+}
+
+- (void)testResizeSectionAllDirections {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+
+    // Test right + bottom
+    struct ResizeSection section1 = { .xResizeDirection = right, .yResizeDirection = bottom };
+    [mr setResizeSection:section1];
+    struct ResizeSection r1 = [mr resizeSection];
+    XCTAssertEqual(r1.xResizeDirection, right);
+    XCTAssertEqual(r1.yResizeDirection, bottom);
+
+    // Test noX + noY (center of window)
+    struct ResizeSection section2 = { .xResizeDirection = noX, .yResizeDirection = noY };
+    [mr setResizeSection:section2];
+    struct ResizeSection r2 = [mr resizeSection];
+    XCTAssertEqual(r2.xResizeDirection, noX);
+    XCTAssertEqual(r2.yResizeDirection, noY);
+}
+
+#pragma mark - wndPosition and wndSize
+
+- (void)testWndPositionStorage {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    NSPoint pos = NSMakePoint(100.0, 200.0);
+    [mr setWndPosition:pos];
+    NSPoint retrieved = [mr wndPosition];
+    XCTAssertEqual(retrieved.x, 100.0);
+    XCTAssertEqual(retrieved.y, 200.0);
+}
+
+- (void)testWndSizeStorage {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+    NSSize size = NSMakeSize(800.0, 600.0);
+    [mr setWndSize:size];
+    NSSize retrieved = [mr wndSize];
+    XCTAssertEqual(retrieved.width, 800.0);
+    XCTAssertEqual(retrieved.height, 600.0);
+}
+
+#pragma mark - State lifecycle (simulating down → drag → up)
+
+- (void)testStateLifecycleMoveOperation {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+
+    // Simulate mouse down for move
+    [mr setTracking:CACurrentMediaTime()];
+    [mr setIsResizing:NO];
+    XCTAssertTrue([mr tracking] > 0, "tracking should be active");
+    XCTAssertFalse([mr isResizing], "should not be resizing for a move");
+
+    // Simulate mouse up
+    [mr setTracking:0];
+    [mr setIsResizing:NO];
+    XCTAssertEqual([mr tracking], 0, "tracking should be cleared");
+    XCTAssertFalse([mr isResizing], "isResizing should be NO after up");
+}
+
+- (void)testStateLifecycleResizeOperation {
+    EMRMoveResize *mr = [EMRMoveResize instance];
+
+    // Simulate mouse down for resize
+    [mr setTracking:CACurrentMediaTime()];
+    [mr setIsResizing:YES];
+    struct ResizeSection section = { .xResizeDirection = right, .yResizeDirection = bottom };
+    [mr setResizeSection:section];
+    [mr setWndPosition:NSMakePoint(50, 50)];
+    [mr setWndSize:NSMakeSize(400, 300)];
+
+    XCTAssertTrue([mr tracking] > 0);
+    XCTAssertTrue([mr isResizing]);
+    XCTAssertEqual([mr resizeSection].xResizeDirection, right);
+    XCTAssertEqual([mr wndSize].width, 400.0);
+
+    // Simulate mouse up
+    [mr setTracking:0];
+    [mr setIsResizing:NO];
+    XCTAssertEqual([mr tracking], 0);
+    XCTAssertFalse([mr isResizing]);
+}
+
+@end

--- a/easy-move-resizeTests/EMRPreferencesTest.m
+++ b/easy-move-resizeTests/EMRPreferencesTest.m
@@ -7,6 +7,7 @@
 
 @implementation EMRPreferencesTest {
     NSString *testDefaultsName;
+    NSUserDefaults *testDefaults;
     EMRPreferences *preferences;
 }
 
@@ -14,14 +15,33 @@
     [super setUp];
     NSString *uuid = [[NSUUID UUID] UUIDString];
     testDefaultsName = [@"org.dmarcotte.Easy-Move-Resize." stringByAppendingString:uuid];
-    NSUserDefaults *userDefaults = [[NSUserDefaults alloc] initWithSuiteName:testDefaultsName];
-    preferences = [[EMRPreferences alloc] initWithUserDefaults:userDefaults];
+    testDefaults = [[NSUserDefaults alloc] initWithSuiteName:testDefaultsName];
+    preferences = [[EMRPreferences alloc] initWithUserDefaults:testDefaults];
 }
 
 - (void)tearDown {
     [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:testDefaultsName];
     [super tearDown];
 }
+
+#pragma mark - Helper: create preferences with pre-existing v1 data (simulates upgrade)
+
+- (EMRPreferences *)createV1PreferencesWithModifiers:(NSString *)flags middleClick:(BOOL)middleClick {
+    NSString *uuid = [[NSUUID UUID] UUIDString];
+    NSString *suiteName = [@"org.dmarcotte.Easy-Move-Resize.v1." stringByAppendingString:uuid];
+    NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
+
+    // Write v1-style preferences (no version key, no resize-specific keys)
+    [defaults setObject:flags forKey:MODIFIER_FLAGS_DEFAULTS_KEY];
+    [defaults setBool:middleClick forKey:SHOULD_MIDDLE_CLICK_RESIZE];
+    [defaults setObject:[NSDictionary dictionary] forKey:DISABLED_APPS_DEFAULTS_KEY];
+
+    // Constructing EMRPreferences triggers migration
+    EMRPreferences *prefs = [[EMRPreferences alloc] initWithUserDefaults:defaults];
+    return prefs;
+}
+
+#pragma mark - Existing test (move modifier reset)
 
 - (void)testResetPreferences {
     [preferences setToDefaults];
@@ -38,6 +58,231 @@
     flagStringSet = [preferences getFlagStringSet];
     expectedSet = [NSSet setWithArray:@[@"CMD", @"CTRL"]];
     XCTAssertEqualObjects(flagStringSet, expectedSet, "Should contain the restored defaults");
+}
+
+#pragma mark - Resize modifier flags
+
+- (void)testResizeModifierDefaults {
+    [preferences setToDefaults];
+    NSSet *resizeFlags = [preferences getResizeFlagStringSet];
+    NSSet *expectedSet = [NSSet setWithArray:@[@"CTRL", @"CMD"]];
+    XCTAssertEqualObjects(resizeFlags, expectedSet, "Resize modifiers should default to CMD+CTRL");
+}
+
+- (void)testSetResizeModifierKey {
+    [preferences setToDefaults];
+
+    [preferences setResizeModifierKey:ALT_KEY enabled:YES];
+    NSSet *resizeFlags = [preferences getResizeFlagStringSet];
+    XCTAssertTrue([resizeFlags containsObject:ALT_KEY], "ALT should be enabled after setting it");
+    XCTAssertTrue([resizeFlags containsObject:CMD_KEY], "CMD should still be enabled");
+    XCTAssertTrue([resizeFlags containsObject:CTRL_KEY], "CTRL should still be enabled");
+
+    [preferences setResizeModifierKey:CTRL_KEY enabled:NO];
+    resizeFlags = [preferences getResizeFlagStringSet];
+    XCTAssertFalse([resizeFlags containsObject:CTRL_KEY], "CTRL should be disabled after removing it");
+    XCTAssertTrue([resizeFlags containsObject:ALT_KEY], "ALT should still be enabled");
+    XCTAssertTrue([resizeFlags containsObject:CMD_KEY], "CMD should still be enabled");
+}
+
+- (void)testResizeModifierFlagsReturnsCorrectBitmask {
+    [preferences setToDefaults];
+    int flags = [preferences resizeModifierFlags];
+    int expected = kCGEventFlagMaskCommand | kCGEventFlagMaskControl;
+    XCTAssertEqual(flags, expected, "Default resize modifier flags should be CMD|CTRL");
+
+    // Change resize to ALT only
+    [preferences setResizeModifierKey:CMD_KEY enabled:NO];
+    [preferences setResizeModifierKey:CTRL_KEY enabled:NO];
+    [preferences setResizeModifierKey:ALT_KEY enabled:YES];
+    flags = [preferences resizeModifierFlags];
+    XCTAssertEqual(flags, (int)kCGEventFlagMaskAlternate, "Resize flags should be ALT only");
+}
+
+- (void)testMoveAndResizeModifiersAreIndependent {
+    [preferences setToDefaults];
+
+    // Change move to CMD only
+    [preferences setModifierKey:CTRL_KEY enabled:NO];
+    // Change resize to ALT+CMD
+    [preferences setResizeModifierKey:CTRL_KEY enabled:NO];
+    [preferences setResizeModifierKey:ALT_KEY enabled:YES];
+
+    NSSet *moveFlags = [preferences getFlagStringSet];
+    NSSet *resizeFlags = [preferences getResizeFlagStringSet];
+
+    XCTAssertEqualObjects(moveFlags, [NSSet setWithArray:@[CMD_KEY]], "Move should be CMD only");
+    NSSet *expectedResize = [NSSet setWithArray:@[CMD_KEY, ALT_KEY]];
+    XCTAssertEqualObjects(resizeFlags, expectedResize, "Resize should be CMD+ALT");
+}
+
+#pragma mark - Mouse button preferences
+
+- (void)testMouseButtonDefaults {
+    [preferences setToDefaults];
+    XCTAssertEqual([preferences moveMouseButton], EMRMouseButtonLeft, "Move mouse button should default to Left");
+    XCTAssertEqual([preferences resizeMouseButton], EMRMouseButtonRight, "Resize mouse button should default to Right");
+}
+
+- (void)testSetMoveMouseButton {
+    [preferences setToDefaults];
+    [preferences setMoveMouseButton:EMRMouseButtonMiddle];
+    XCTAssertEqual([preferences moveMouseButton], EMRMouseButtonMiddle, "Move mouse button should be Middle after setting");
+}
+
+- (void)testSetResizeMouseButton {
+    [preferences setToDefaults];
+    [preferences setResizeMouseButton:EMRMouseButtonLeft];
+    XCTAssertEqual([preferences resizeMouseButton], EMRMouseButtonLeft, "Resize mouse button should be Left after setting");
+}
+
+- (void)testResizeMouseButtonDefaultsToRightWhenUnset {
+    // Fresh defaults with no resize mouse button key set — should return Right
+    // setUp already creates a fresh preferences with setToDefaults called,
+    // but let's test the nil-key path explicitly
+    NSString *uuid = [[NSUUID UUID] UUIDString];
+    NSString *suiteName = [@"org.dmarcotte.Easy-Move-Resize.niltest." stringByAppendingString:uuid];
+    NSUserDefaults *freshDefaults = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
+    // setToDefaults will be called by init since ModifierFlags is nil
+    EMRPreferences *freshPrefs = [[EMRPreferences alloc] initWithUserDefaults:freshDefaults];
+    XCTAssertEqual([freshPrefs resizeMouseButton], EMRMouseButtonRight, "Resize should default to Right");
+    [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:suiteName];
+}
+
+#pragma mark - Conflict detection
+
+- (void)testNoConflictWithDefaultSettings {
+    [preferences setToDefaults];
+    XCTAssertFalse([preferences hasConflictingConfig], "Default settings should not conflict (different mouse buttons)");
+}
+
+- (void)testConflictWhenSameButtonAndSameModifiers {
+    [preferences setToDefaults];
+    // Set both to left-click with same modifiers
+    [preferences setMoveMouseButton:EMRMouseButtonLeft];
+    [preferences setResizeMouseButton:EMRMouseButtonLeft];
+    XCTAssertTrue([preferences hasConflictingConfig], "Same button + same modifiers should conflict");
+}
+
+- (void)testNoConflictWhenSameButtonDifferentModifiers {
+    [preferences setToDefaults];
+    // Both left-click, but different modifiers
+    [preferences setMoveMouseButton:EMRMouseButtonLeft];
+    [preferences setResizeMouseButton:EMRMouseButtonLeft];
+    [preferences setResizeModifierKey:ALT_KEY enabled:YES];
+    [preferences setResizeModifierKey:CTRL_KEY enabled:NO];
+    XCTAssertFalse([preferences hasConflictingConfig], "Same button but different modifiers should not conflict");
+}
+
+- (void)testNoConflictWhenDifferentButtonSameModifiers {
+    [preferences setToDefaults];
+    // Same modifiers, but different buttons
+    [preferences setMoveMouseButton:EMRMouseButtonLeft];
+    [preferences setResizeMouseButton:EMRMouseButtonRight];
+    XCTAssertFalse([preferences hasConflictingConfig], "Different buttons with same modifiers should not conflict");
+}
+
+#pragma mark - Preference migration from v1
+
+- (void)testMigrationCopiesModifierFlagsToResize {
+    EMRPreferences *migrated = [self createV1PreferencesWithModifiers:@"CMD,ALT" middleClick:NO];
+    NSSet *resizeFlags = [migrated getResizeFlagStringSet];
+    NSSet *expected = [NSSet setWithArray:@[CMD_KEY, ALT_KEY]];
+    XCTAssertEqualObjects(resizeFlags, expected, "Migration should copy move modifiers to resize modifiers");
+}
+
+- (void)testMigrationMiddleClickToResizeMouseButton {
+    EMRPreferences *migrated = [self createV1PreferencesWithModifiers:@"CMD,CTRL" middleClick:YES];
+    XCTAssertEqual([migrated resizeMouseButton], EMRMouseButtonMiddle,
+                   "Migration should set resize mouse button to Middle when MiddleClickResize was ON");
+}
+
+- (void)testMigrationNoMiddleClickKeepsDefaultRight {
+    EMRPreferences *migrated = [self createV1PreferencesWithModifiers:@"CMD,CTRL" middleClick:NO];
+    XCTAssertEqual([migrated resizeMouseButton], EMRMouseButtonRight,
+                   "Migration without MiddleClickResize should keep resize button as Right (default)");
+}
+
+- (void)testMigrationRunsOnlyOnce {
+    // Create v1 prefs, triggering migration
+    NSString *uuid = [[NSUUID UUID] UUIDString];
+    NSString *suiteName = [@"org.dmarcotte.Easy-Move-Resize.migrateonce." stringByAppendingString:uuid];
+    NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
+    [defaults setObject:@"CMD,ALT" forKey:MODIFIER_FLAGS_DEFAULTS_KEY];
+    [defaults setBool:YES forKey:SHOULD_MIDDLE_CLICK_RESIZE];
+    [defaults setObject:[NSDictionary dictionary] forKey:DISABLED_APPS_DEFAULTS_KEY];
+
+    // First init triggers migration
+    EMRPreferences *prefs1 = [[EMRPreferences alloc] initWithUserDefaults:defaults];
+    XCTAssertEqual([prefs1 resizeMouseButton], EMRMouseButtonMiddle);
+
+    // Now change resize mouse button to Left
+    [prefs1 setResizeMouseButton:EMRMouseButtonLeft];
+    XCTAssertEqual([prefs1 resizeMouseButton], EMRMouseButtonLeft);
+
+    // Re-init — migration should NOT run again (version is already 2)
+    EMRPreferences *prefs2 = [[EMRPreferences alloc] initWithUserDefaults:defaults];
+    XCTAssertEqual([prefs2 resizeMouseButton], EMRMouseButtonLeft,
+                   "Second init should not re-run migration and overwrite user's choice");
+
+    [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:suiteName];
+}
+
+#pragma mark - setToDefaults comprehensive
+
+- (void)testSetToDefaultsResetsAllFields {
+    [preferences setToDefaults];
+
+    // Modify everything
+    [preferences setModifierKey:ALT_KEY enabled:YES];
+    [preferences setResizeModifierKey:SHIFT_KEY enabled:YES];
+    [preferences setMoveMouseButton:EMRMouseButtonMiddle];
+    [preferences setResizeMouseButton:EMRMouseButtonLeft];
+    [preferences setShouldBringWindowToFront:YES];
+    [preferences setResizeOnly:YES];
+
+    // Reset
+    [preferences setToDefaults];
+
+    NSSet *moveFlags = [preferences getFlagStringSet];
+    NSSet *resizeFlags = [preferences getResizeFlagStringSet];
+    NSSet *expectedModifiers = [NSSet setWithArray:@[CMD_KEY, CTRL_KEY]];
+
+    XCTAssertEqualObjects(moveFlags, expectedModifiers, "Move modifiers should reset to CMD+CTRL");
+    XCTAssertEqualObjects(resizeFlags, expectedModifiers, "Resize modifiers should reset to CMD+CTRL");
+    XCTAssertEqual([preferences moveMouseButton], EMRMouseButtonLeft, "Move button should reset to Left");
+    XCTAssertEqual([preferences resizeMouseButton], EMRMouseButtonRight, "Resize button should reset to Right");
+    XCTAssertFalse([preferences shouldBringWindowToFront], "Bring to front should reset to NO");
+    XCTAssertFalse([preferences resizeOnly], "Resize only should reset to NO");
+    XCTAssertFalse([preferences hasConflictingConfig], "Defaults should not conflict");
+}
+
+#pragma mark - Edge cases
+
+- (void)testAllModifiersUncheckedReturnsZeroFlags {
+    [preferences setToDefaults];
+    [preferences setResizeModifierKey:CMD_KEY enabled:NO];
+    [preferences setResizeModifierKey:CTRL_KEY enabled:NO];
+    XCTAssertEqual([preferences resizeModifierFlags], 0, "All modifiers unchecked should return 0");
+}
+
+- (void)testAllMoveModifiersUncheckedReturnsZeroFlags {
+    [preferences setToDefaults];
+    [preferences setModifierKey:CMD_KEY enabled:NO];
+    [preferences setModifierKey:CTRL_KEY enabled:NO];
+    XCTAssertEqual([preferences modifierFlags], 0, "All move modifiers unchecked should return 0");
+}
+
+- (void)testConflictWithAllModifiersUnchecked {
+    [preferences setToDefaults];
+    // Both operations: left-click, no modifiers
+    [preferences setMoveMouseButton:EMRMouseButtonLeft];
+    [preferences setResizeMouseButton:EMRMouseButtonLeft];
+    [preferences setModifierKey:CMD_KEY enabled:NO];
+    [preferences setModifierKey:CTRL_KEY enabled:NO];
+    [preferences setResizeModifierKey:CMD_KEY enabled:NO];
+    [preferences setResizeModifierKey:CTRL_KEY enabled:NO];
+    XCTAssertTrue([preferences hasConflictingConfig], "Same button + same (empty) modifiers should conflict");
 }
 
 @end


### PR DESCRIPTION
Adds the ability to configure Move and Resize independently — each with their own modifier keys and mouse button — so users can resize with left-click + a different modifier combination instead of requiring right-click.

Closes #69

## Motivation
The now-defunct Zooom/2 had this ability, and as noted in #69, requiring right-click for resize is awkward on a Mac trackpad. This PR brings the same flexibility: for example, you can set Cmd+Ctrl+Left-click to move and Cmd+Alt+Left-click to resize.

## What changed
**Preferences** — New independent settings for resize modifier keys and mouse button (Left/Right/Middle), with conflict detection when Move and Resize have identical config. Existing user preferences are automatically migrated on first launch (modifier keys copied to resize, the old MiddleClickResize toggle converted to the new mouse button setting). Migration is version-gated and runs only once.

**Callback logic** — The CGEvent callback now matches Move and Resize independently based on their separate modifier flags and mouse button. When both match (conflict), resize wins. A new isResizing property on EMRMoveResize tracks which operation is active during drag.

**Menu UI** — The old shared modifier toggles are replaced with programmatically-built Move and Resize sections, each with their own modifier key checkboxes and mouse button submenu (Left/Right/Middle). A conflict warning appears when both operations have identical settings. "Resize only" greys out the Move section.

**Tests** — 49 unit tests covering preferences, callback logic, and model state. The XCTest guard skips the accessibility prompt so tests run without user interaction.

Default behavior is unchanged
Move = Cmd+Ctrl on Left-click, Resize = Cmd+Ctrl on Right-click — same as before.

**Screenshot**
<img width="279" height="650" alt="image" src="https://github.com/user-attachments/assets/7f02a571-6f71-4d96-a5bf-bdef237865a9" />
