### PR TITLE
Add a github actions workflow to automatically sign+notarize releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    name: validate (act-testable)
+    name: validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -65,6 +65,7 @@ jobs:
 
   sign-and-notarize:
     name: sign + notarize (macOS)
+    environment: release
     runs-on: macos-latest
     needs: archive
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     name: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Sanity-check repo layout
         run: |
@@ -43,7 +43,7 @@ jobs:
     runs-on: macos-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Show Xcode version
         run: xcodebuild -version
@@ -66,7 +66,7 @@ jobs:
           mkdir -p artifact
           ditto -c -k --keepParent "$APP" "artifact/Easy Move+Resize.unsigned.zip"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: easy-move-resize-unsigned
           path: artifact/Easy Move+Resize.unsigned.zip
@@ -82,9 +82,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: easy-move-resize-unsigned
           path: artifact
@@ -106,7 +106,7 @@ jobs:
           DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
         run: ./scripts/sign-and-notarize.sh "dist/Easy Move+Resize.app"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: easy-move-resize-signed
           path: dist/Easy Move+Resize.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,16 @@ name: release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v1.2.3). Creates a tag and GitHub Release.'
+        required: true
+        type: string
+      prerelease:
+        description: 'Mark as pre-release'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -69,6 +79,8 @@ jobs:
     runs-on: macos-latest
     needs: archive
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -99,3 +111,13 @@ jobs:
           name: easy-move-resize-signed
           path: dist/Easy Move+Resize.zip
           if-no-files-found: error
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.version }}
+          name: ${{ inputs.version }}
+          prerelease: ${{ inputs.prerelease }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: dist/Easy Move+Resize.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           mkdir -p artifact
           ditto -c -k --keepParent "$APP" "artifact/Easy Move+Resize.unsigned.zip"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: easy-move-resize-unsigned
           path: artifact/Easy Move+Resize.unsigned.zip
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v7
         with:
           name: easy-move-resize-unsigned
           path: artifact
@@ -106,14 +106,14 @@ jobs:
           DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
         run: ./scripts/sign-and-notarize.sh "dist/Easy Move+Resize.app"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: easy-move-resize-signed
           path: dist/Easy Move+Resize.zip
           if-no-files-found: error
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.version }}
           name: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,6 @@ jobs:
 
   sign-and-notarize:
     name: sign + notarize (macOS)
-    environment: release
     runs-on: macos-latest
     needs: archive
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: validate (act-testable)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sanity-check repo layout
+        run: |
+          set -euo pipefail
+          test -f easy-move-resize.xcodeproj/project.pbxproj
+          test -f easy-move-resize/easy-move-resize-Info.plist
+          test -x scripts/sign-and-notarize.sh
+
+      - name: Shellcheck the sign script
+        run: |
+          if ! command -v shellcheck >/dev/null; then
+            apt-get update && apt-get install -y shellcheck || sudo apt-get install -y shellcheck
+          fi
+          shellcheck scripts/sign-and-notarize.sh
+
+      - name: Validate Info.plist (xml well-formed)
+        run: |
+          python3 -c "import plistlib,sys; plistlib.loads(open('easy-move-resize/easy-move-resize-Info.plist','rb').read())"
+
+  archive:
+    name: archive (macOS)
+    runs-on: macos-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Build .app (unsigned)
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project easy-move-resize.xcodeproj \
+            -scheme easy-move-resize \
+            -configuration Release \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            clean build
+
+          APP="build/Build/Products/Release/Easy Move+Resize.app"
+          test -d "$APP" || { echo "missing built app at: $APP"; exit 1; }
+
+          # Tar preserves perms/symlinks across artifact upload/download.
+          mkdir -p artifact
+          ditto -c -k --keepParent "$APP" "artifact/Easy Move+Resize.unsigned.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: easy-move-resize-unsigned
+          path: artifact/Easy Move+Resize.unsigned.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  sign-and-notarize:
+    name: sign + notarize (macOS)
+    runs-on: macos-latest
+    needs: archive
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: easy-move-resize-unsigned
+          path: artifact
+
+      - name: Unzip built app
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          ditto -x -k "artifact/Easy Move+Resize.unsigned.zip" dist
+          test -d "dist/Easy Move+Resize.app"
+
+      - name: Sign, notarize, staple
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          DEVELOPER_ID_APPLICATION: ${{ secrets.DEVELOPER_ID_APPLICATION }}
+          DEVELOPER_ID_CERT_P12_BASE64: ${{ secrets.DEVELOPER_ID_CERT_P12_BASE64 }}
+          DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+        run: ./scripts/sign-and-notarize.sh "dist/Easy Move+Resize.app"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: easy-move-resize-signed
+          path: dist/Easy Move+Resize.zip
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ DerivedData
 
 # mardown previews
 *.md.html
+
+# Local secrets for act / sign-and-notarize.sh
+.secrets

--- a/.secrets.example
+++ b/.secrets.example
@@ -1,0 +1,31 @@
+# Copy this file to `.secrets` (gitignored) for local `act` runs and for
+# sourcing when running scripts/sign-and-notarize.sh directly on your Mac.
+#
+# On GitHub, configure these as repository secrets with the same names
+# (Settings -> Secrets and variables -> Actions).
+
+# Apple ID email (used by notarytool)
+APPLE_ID=you@example.com
+
+# 10-character Apple Developer Team ID (visible at developer.apple.com -> Membership)
+APPLE_TEAM_ID=ABCDE12345
+
+# App-specific password for APPLE_ID. Generate at https://account.apple.com
+# under "Sign-In and Security" -> "App-Specific Passwords".
+APPLE_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
+
+# Full common name of the Developer ID Application identity. Find it with:
+#   security find-identity -v -p codesigning
+# It should look exactly like:
+#   Developer ID Application: Your Name (ABCDE12345)
+DEVELOPER_ID_APPLICATION=Developer ID Application: Your Name (ABCDE12345)
+
+# --- CI-only: certificate import (leave blank when running locally) ----------
+# Base64-encoded .p12 export of the Developer ID Application identity.
+# Generate with:
+#   base64 -i DeveloperID.p12 | pbcopy
+# (or `base64 -w0 DeveloperID.p12` on Linux)
+DEVELOPER_ID_CERT_P12_BASE64=
+
+# Password used when exporting the .p12 from Keychain Access.
+DEVELOPER_ID_CERT_PASSWORD=

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,33 @@ brew install --cask easy-move-plus-resize
 
 ## Release process
 
+### Automated (GitHub Actions)
+
+Releases can be built, signed, notarized, and published automatically via the [`release`](.github/workflows/release.yml) workflow.
+
+Prerequisites — the following secrets must be configured in the repository's GitHub Actions settings:
+
+- `APPLE_ID` — Apple ID email used for notarization
+- `APPLE_TEAM_ID` — Apple Developer Team ID
+- `APPLE_APP_PASSWORD` — app-specific password for the Apple ID
+- `DEVELOPER_ID_APPLICATION` — full name of the Developer ID Application signing identity (e.g. `Developer ID Application: Your Name (TEAMID)`)
+- `DEVELOPER_ID_CERT_P12_BASE64` — base64-encoded `.p12` export of the Developer ID Application certificate
+- `DEVELOPER_ID_CERT_PASSWORD` — password for the `.p12` file
+
+Steps:
+
+- Choose a new version number following [semantic versioning guidelines](https://semver.org)
+- Update the version number in [`easy-move-resize/easy-move-resize-Info.plist`](easy-move-resize/easy-move-resize-Info.plist), ([example](https://github.com/dmarcotte/easy-move-resize/commit/18d759dec2caf7a33b0625c17c181a195191bc92))
+- Commit and push the version number update
+- `git tag <chosen version number>`
+- `git push origin --tags`
+- On GitHub, go to the [Actions tab](https://github.com/dmarcotte/easy-move-resize/actions), select the **release** workflow, and click **Run workflow**
+- Enter the release version (e.g. `v1.2.3`), toggle **Mark as pre-release** if applicable, then click **Run workflow**
+- The workflow validates the repo, builds the `.app` with `xcodebuild`, signs/notarizes/staples it, creates the git tag, and publishes a GitHub Release with the signed zip attached
+- Once the workflow completes, the new release will appear on the [Releases page](https://github.com/dmarcotte/easy-move-resize/releases)
+
+### Manual (backup)
+
 - Choose a new version number following [semantic versioning guidelines](https://semver.org)
 - Update the version number in [`easy-move-resize/easy-move-resize-Info.plist`](easy-move-resize/easy-move-resize-Info.plist), ([example](https://github.com/dmarcotte/easy-move-resize/commit/18d759dec2caf7a33b0625c17c181a195191bc92))
 - Commit and push the version number update

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Sign, notarize, and staple a macOS .app bundle.
+#
+# Usage: scripts/sign-and-notarize.sh <path/to/Foo.app>
+#
+# Required env vars:
+#   APPLE_ID                   Apple ID email used for notarization
+#   APPLE_TEAM_ID              10-char Apple Developer Team ID
+#   APPLE_APP_PASSWORD         App-specific password for APPLE_ID (notarytool)
+#   DEVELOPER_ID_APPLICATION   Full common name of the signing identity, e.g.
+#                              "Developer ID Application: Jane Doe (ABCDE12345)"
+#
+# Optional (CI keychain import; if both set, a temp keychain is created and
+# the cert is imported before signing):
+#   DEVELOPER_ID_CERT_P12_BASE64   base64-encoded .p12 export of the identity
+#   DEVELOPER_ID_CERT_PASSWORD     password used when exporting the .p12
+#
+# Exits non-zero on any failure with a clear message.
+
+set -euo pipefail
+
+log()  { printf '\033[1;34m[sign]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[sign:FAIL]\033[0m %s\n' "$*" >&2; exit 1; }
+
+[[ $# -eq 1 ]] || fail "usage: $0 <path/to/Foo.app>"
+APP_PATH="$1"
+[[ -d "$APP_PATH" ]] || fail "app bundle not found: $APP_PATH"
+[[ "$APP_PATH" == *.app ]] || fail "expected a .app bundle, got: $APP_PATH"
+
+require() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then fail "missing required env var: $name"; fi
+}
+require APPLE_ID
+require APPLE_TEAM_ID
+require APPLE_APP_PASSWORD
+require DEVELOPER_ID_APPLICATION
+
+command -v codesign  >/dev/null || fail "codesign not on PATH (run on macOS)"
+command -v xcrun     >/dev/null || fail "xcrun not on PATH (run on macOS)"
+command -v ditto     >/dev/null || fail "ditto not on PATH"
+
+KEYCHAIN_PATH=""
+cleanup() {
+  if [[ -n "$KEYCHAIN_PATH" && -f "$KEYCHAIN_PATH" ]]; then
+    log "removing temp keychain"
+    security delete-keychain "$KEYCHAIN_PATH" || true
+  fi
+}
+trap cleanup EXIT
+
+# ---- 1. Optional: import signing cert into a temp keychain (CI) -------------
+if [[ -n "${DEVELOPER_ID_CERT_P12_BASE64:-}" ]]; then
+  [[ -n "${DEVELOPER_ID_CERT_PASSWORD:-}" ]] \
+    || fail "DEVELOPER_ID_CERT_P12_BASE64 set but DEVELOPER_ID_CERT_PASSWORD is not"
+  log "importing signing certificate into a temporary keychain"
+
+  : "${RUNNER_TEMP:=$(mktemp -d)}"
+  KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+  KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+  P12_PATH="$RUNNER_TEMP/cert.p12"
+
+  echo "$DEVELOPER_ID_CERT_P12_BASE64" | base64 --decode > "$P12_PATH" \
+    || fail "failed to base64-decode DEVELOPER_ID_CERT_P12_BASE64"
+
+  security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+  security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+  security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+  security import "$P12_PATH" -P "$DEVELOPER_ID_CERT_PASSWORD" \
+    -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH" \
+    || fail "security import failed"
+  security set-key-partition-list -S apple-tool:,apple:,codesign: \
+    -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+
+  # Prepend our keychain to the search list so codesign finds the identity.
+  ORIG_LIST=$(security list-keychains -d user | tr -d '"' | xargs)
+  # shellcheck disable=SC2086
+  security list-keychains -d user -s "$KEYCHAIN_PATH" $ORIG_LIST
+
+  rm -f "$P12_PATH"
+fi
+
+# ---- 2. Verify the identity is available ------------------------------------
+log "checking for signing identity: $DEVELOPER_ID_APPLICATION"
+if ! security find-identity -v -p codesigning | grep -q "$DEVELOPER_ID_APPLICATION"; then
+  security find-identity -v -p codesigning >&2 || true
+  fail "signing identity not found in any keychain: $DEVELOPER_ID_APPLICATION"
+fi
+
+# ---- 3. Codesign with hardened runtime --------------------------------------
+log "codesigning $APP_PATH"
+codesign --force --options runtime --timestamp \
+  --sign "$DEVELOPER_ID_APPLICATION" \
+  "$APP_PATH" \
+  || fail "codesign failed"
+
+log "verifying signature"
+codesign --verify --deep --strict --verbose=2 "$APP_PATH" \
+  || fail "codesign verify failed"
+
+# ---- 4. Zip for notarization -----------------------------------------------
+APP_DIR="$(cd "$(dirname "$APP_PATH")" && pwd)"
+APP_NAME="$(basename "$APP_PATH")"
+ZIP_PATH="$APP_DIR/${APP_NAME%.app}.zip"
+
+log "zipping for notarization: $ZIP_PATH"
+rm -f "$ZIP_PATH"
+ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH" \
+  || fail "ditto zip failed"
+
+# ---- 5. Submit to notarytool, wait for result -------------------------------
+log "submitting to notarytool (this can take several minutes)"
+NOTARY_LOG="$(mktemp)"
+if ! xcrun notarytool submit "$ZIP_PATH" \
+      --apple-id "$APPLE_ID" \
+      --team-id  "$APPLE_TEAM_ID" \
+      --password "$APPLE_APP_PASSWORD" \
+      --wait \
+      --output-format plist > "$NOTARY_LOG"; then
+  cat "$NOTARY_LOG" >&2 || true
+  fail "notarytool submit failed"
+fi
+cat "$NOTARY_LOG"
+
+STATUS=$(/usr/libexec/PlistBuddy -c "Print :status" "$NOTARY_LOG" 2>/dev/null || echo "unknown")
+if [[ "$STATUS" != "Accepted" ]]; then
+  SUBMISSION_ID=$(/usr/libexec/PlistBuddy -c "Print :id" "$NOTARY_LOG" 2>/dev/null || echo "")
+  if [[ -n "$SUBMISSION_ID" ]]; then
+    log "fetching notarization log for $SUBMISSION_ID"
+    xcrun notarytool log "$SUBMISSION_ID" \
+      --apple-id "$APPLE_ID" \
+      --team-id  "$APPLE_TEAM_ID" \
+      --password "$APPLE_APP_PASSWORD" >&2 || true
+  fi
+  fail "notarization status: $STATUS (expected Accepted)"
+fi
+
+# ---- 6. Staple --------------------------------------------------------------
+log "stapling ticket to $APP_PATH"
+xcrun stapler staple "$APP_PATH" || fail "stapler failed"
+xcrun stapler validate "$APP_PATH" || fail "stapler validate failed"
+
+# ---- 7. Final Gatekeeper assessment ----------------------------------------
+log "spctl assessment"
+spctl --assess --type execute --verbose=4 "$APP_PATH" \
+  || fail "spctl assessment failed"
+
+# Re-zip the stapled app so the artifact in $ZIP_PATH is the shippable one.
+log "re-zipping stapled app"
+rm -f "$ZIP_PATH"
+ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+
+log "done: $APP_PATH"
+log "shippable zip: $ZIP_PATH"


### PR DESCRIPTION
Currently the release process is manual -- we need to sign and notarize on a local mac. This change allows any repo owner to create a new release using my Apple ID Developer credentials using Github Actions. 

Limitations: Kicking off a new build + version name still needs to be provided manually. We can update this to automatically apply to new version tags, but I think this is fine for now. 

