### PR TITLE
Smoother window updates using v-sync

### DIFF
--- a/easy-move-resize.xcodeproj/project.pbxproj
+++ b/easy-move-resize.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		6ED47B7B183BF3E800859244 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6ED47B79183BF3E800859244 /* MainMenu.xib */; };
 		6ED47B7D183BF3E800859244 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6ED47B7C183BF3E800859244 /* Images.xcassets */; };
 		B02F18934323BB42D8CCAB05 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B02F125CE1BC18D269C53372 /* QuartzCore.framework */; };
+		EMR0000001000000000000001 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EMR0000002000000000000001 /* CoreVideo.framework */; };
 		F907A25928093AED2C89550E /* EMRMoveResize.m in Sources */ = {isa = PBXBuildFile; fileRef = F907AEB04B0AF90540F6EF00 /* EMRMoveResize.m */; };
 		F907A53FB2CAEBEB31895CD2 /* contributing.md in Resources */ = {isa = PBXBuildFile; fileRef = F907A3568D9301F4E6A9736F /* contributing.md */; };
 		F907ABDDEEAF5BF83F0AF9EA /* readme.md in Resources */ = {isa = PBXBuildFile; fileRef = F907A4D20267246716869421 /* readme.md */; };
@@ -52,6 +53,7 @@
 		6ED47B7C183BF3E800859244 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		6ED47B83183BF3E800859244 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		B02F125CE1BC18D269C53372 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		EMR0000002000000000000001 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
 		F907A0E10208B2B4C63E46E3 /* LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		F907A3568D9301F4E6A9736F /* contributing.md */ = {isa = PBXFileReference; lastKnownFileType = file.md; path = contributing.md; sourceTree = "<group>"; };
 		F907A4D20267246716869421 /* readme.md */ = {isa = PBXFileReference; lastKnownFileType = file.md; path = readme.md; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 			files = (
 				6ED47B65183BF3E800859244 /* Cocoa.framework in Frameworks */,
 				B02F18934323BB42D8CCAB05 /* QuartzCore.framework in Frameworks */,
+				EMR0000001000000000000001 /* CoreVideo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,6 +122,7 @@
 				6ED47B83183BF3E800859244 /* XCTest.framework */,
 				6ED47B66183BF3E800859244 /* Other Frameworks */,
 				B02F125CE1BC18D269C53372 /* QuartzCore.framework */,
+				EMR0000002000000000000001 /* CoreVideo.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/easy-move-resize/EMRAppDelegate.h
+++ b/easy-move-resize/EMRAppDelegate.h
@@ -29,7 +29,5 @@
 @property (weak) IBOutlet NSMenuItem *disabledAppsMenu;
 @property (weak) IBOutlet NSMenuItem *lastAppMenu;
 @property (nonatomic) BOOL sessionActive;
-@property float moveFilterInterval;
-@property float resizeFilterInterval;
 
 @end

--- a/easy-move-resize/EMRAppDelegate.m
+++ b/easy-move-resize/EMRAppDelegate.m
@@ -2,18 +2,6 @@
 #import "EMRMoveResize.h"
 #import "EMRPreferences.h"
 
-/* Return the minimum refresh interval (1/refresh rate) across all screens. If the user
- * is on a version of MacOS < 12.0 then 60hz refresh rate is assumed. */
-float getMinRefreshInterval(void) {
-    float minInterval = 1.0 / 60;
-    for (unsigned i=0; i<NSScreen.screens.count; ++i) {
-        if (@available(macOS 12.0, *)) {
-            minInterval = MIN(minInterval, NSScreen.screens[i].minimumRefreshInterval);
-        }
-    }
-    return minInterval;
-}
-
 @implementation EMRAppDelegate {
     EMRPreferences *preferences;
 }
@@ -23,11 +11,6 @@ float getMinRefreshInterval(void) {
     if (self) {
         NSUserDefaults *userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"userPrefs"];
         preferences = [[EMRPreferences alloc] initWithUserDefaults:userDefaults];
-
-        // Window move and resize based on minimum refresh interval across all screens
-        const float refreshRate = getMinRefreshInterval();
-        self.moveFilterInterval = refreshRate;
-        self.resizeFilterInterval = refreshRate;
     }
     return self;
 }
@@ -46,7 +29,6 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     if (![ourDelegate sessionActive]) {
         return event;
     }
-
     if (keyModifierFlags == 0) {
         // No modifier keys set. Disable behaviour.
         return event;
@@ -139,12 +121,12 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
         [moveResize setWndPosition:cTopLeft];
         [moveResize setWindow:_clickedWindow];
         if (_clickedWindow != nil) CFRelease(_clickedWindow);
+        [moveResize startDisplayLink];
         handled = YES;
     }
 
     if (type == kCGEventLeftMouseDragged
             && [moveResize tracking] > 0) {
-        AXUIElementRef _clickedWindow = [moveResize window];
         double deltaX = CGEventGetDoubleValueField(event, kCGMouseEventDeltaX);
         double deltaY = CGEventGetDoubleValueField(event, kCGMouseEventDeltaY);
 
@@ -153,15 +135,7 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
         thePoint.x = cTopLeft.x + deltaX;
         thePoint.y = cTopLeft.y + deltaY;
         [moveResize setWndPosition:thePoint];
-        CFTypeRef _position;
-
-        // actually applying the change is expensive, so only do it every kMoveFilterInterval seconds
-        if (CACurrentMediaTime() - [moveResize tracking] > ourDelegate.moveFilterInterval) {
-            _position = (CFTypeRef) (AXValueCreate(kAXValueCGPointType, (const void *) &thePoint));
-            AXUIElementSetAttributeValue(_clickedWindow, (__bridge CFStringRef) NSAccessibilityPositionAttribute, (CFTypeRef *) _position);
-            if (_position != NULL) CFRelease(_position);
-            [moveResize setTracking:CACurrentMediaTime()];
-        }
+        [moveResize updatePosition:thePoint];
         handled = YES;
     }
 
@@ -212,7 +186,6 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
     if (type == resizeModifierDragged
             && [moveResize tracking] > 0) {
-        AXUIElementRef _clickedWindow = [moveResize window];
         struct ResizeSection resizeSection = [moveResize resizeSection];
         int deltaX = (int) CGEventGetDoubleValueField(event, kCGMouseEventDeltaX);
         int deltaY = (int) CGEventGetDoubleValueField(event, kCGMouseEventDeltaY);
@@ -252,26 +225,14 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
         [moveResize setWndPosition:cTopLeft];
         [moveResize setWndSize:wndSize];
-
-        // actually applying the change is expensive, so only do it every kResizeFilterInterval events
-        if (CACurrentMediaTime() - [moveResize tracking] > ourDelegate.resizeFilterInterval) {
-            // only make a call to update the position if we need to
-            if (resizeSection.xResizeDirection == left || resizeSection.yResizeDirection == bottom) {
-                CFTypeRef _position = (CFTypeRef)(AXValueCreate(kAXValueCGPointType, (const void *)&cTopLeft));
-                AXUIElementSetAttributeValue(_clickedWindow, (__bridge CFStringRef)NSAccessibilityPositionAttribute, (CFTypeRef *)_position);
-                CFRelease(_position);
-            }
-
-            CFTypeRef _size = (CFTypeRef)(AXValueCreate(kAXValueCGSizeType, (const void *)&wndSize));
-            AXUIElementSetAttributeValue((AXUIElementRef)_clickedWindow, (__bridge CFStringRef)NSAccessibilitySizeAttribute, (CFTypeRef *)_size);
-            CFRelease(_size);
-            [moveResize setTracking:CACurrentMediaTime()];
-        }
+        [moveResize updatePositionAndSize:cTopLeft size:wndSize resizeSection:resizeSection];
         handled = YES;
     }
 
     if ((type == kCGEventLeftMouseUp || type == resizeModifierUp)
         && [moveResize tracking] > 0) {
+        [moveResize applyPendingChanges];
+        [moveResize stopDisplayLink];
         [moveResize setTracking:0];
         handled = YES;
     }
@@ -342,6 +303,7 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
     [moveResize setRunLoopSource:runLoopSource];
     [self enableRunLoopSource:moveResize];
     CFRelease(runLoopSource);
+    [moveResize setupDisplayLink];
 
     _sessionActive = true;
     [[[NSWorkspace sharedWorkspace] notificationCenter]
@@ -355,6 +317,12 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
             selector:@selector(becameInactive:)
             name:NSWorkspaceSessionDidResignActiveNotification
             object:nil];
+
+    [[NSNotificationCenter defaultCenter]
+            addObserver:self
+            selector:@selector(screensDidChange:)
+            name:NSApplicationDidChangeScreenParametersNotification
+            object:nil];
     
     [self reconstructDisabledAppsSubmenu];
 }
@@ -365,6 +333,10 @@ CGEventRef myCGEventCallback(CGEventTapProxy __unused proxy, CGEventType type, C
 
 - (void)becameInactive:(NSNotification*) notification {
     _sessionActive = false;
+}
+
+- (void)screensDidChange:(NSNotification*) notification {
+    [[EMRMoveResize instance] setupDisplayLink];
 }
 
 -(void)awakeFromNib{

--- a/easy-move-resize/EMRMoveResize.h
+++ b/easy-move-resize/EMRMoveResize.h
@@ -1,4 +1,6 @@
 #import <Foundation/Foundation.h>
+#import <CoreVideo/CVDisplayLink.h>
+#import <os/lock.h>
 
 enum ResizeDirectionX {
     right,
@@ -17,6 +19,21 @@ struct ResizeSection {
     enum ResizeSectionY yResizeDirection;
 };
 
+typedef enum {
+    EMROperationNone,
+    EMROperationMove,
+    EMROperationResize
+} EMROperationType;
+
+typedef struct {
+    NSPoint              position;
+    NSSize               size;
+    EMROperationType     operation;
+    struct ResizeSection  resizeSection;
+    BOOL                 dirty;
+    AXUIElementRef       window;
+} EMRDisplayState;
+
 @interface EMRMoveResize : NSObject {
     CFMachPortRef _eventTap;
     CFRunLoopSourceRef _runLoopSource;
@@ -25,6 +42,10 @@ struct ResizeSection {
     CFTimeInterval _tracking;
     NSPoint _wndPosition;
     NSSize _wndSize;
+
+    CVDisplayLinkRef _displayLink;
+    os_unfair_lock _displayStateLock;
+    EMRDisplayState _displayState;
 }
 
 + (id) instance;
@@ -36,5 +57,12 @@ struct ResizeSection {
 @property CFTimeInterval tracking;
 @property NSPoint wndPosition;
 @property NSSize wndSize;
+
+- (void)setupDisplayLink;
+- (void)startDisplayLink;
+- (void)stopDisplayLink;
+- (void)updatePosition:(NSPoint)position;
+- (void)updatePositionAndSize:(NSPoint)position size:(NSSize)size resizeSection:(struct ResizeSection)resizeSection;
+- (void)applyPendingChanges;
 
 @end

--- a/easy-move-resize/EMRMoveResize.m
+++ b/easy-move-resize/EMRMoveResize.m
@@ -1,5 +1,16 @@
 #import "EMRMoveResize.h"
 
+static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
+                                     const CVTimeStamp *inNow,
+                                     const CVTimeStamp *inOutputTime,
+                                     CVOptionFlags flagsIn,
+                                     CVOptionFlags *flagsOut,
+                                     void *displayLinkContext) {
+    EMRMoveResize *moveResize = (__bridge EMRMoveResize *)displayLinkContext;
+    [moveResize applyPendingChanges];
+    return kCVReturnSuccess;
+}
+
 @implementation EMRMoveResize
 @synthesize eventTap = _eventTap;
 @synthesize resizeSection = _resizeSection;
@@ -20,6 +31,9 @@
 - init {
     _window = nil;
     _runLoopSource = nil;
+    _displayLink = NULL;
+    _displayStateLock = OS_UNFAIR_LOCK_INIT;
+    memset(&_displayState, 0, sizeof(_displayState));
     return self;
 }
 
@@ -43,7 +57,82 @@
     _runLoopSource = runLoopSource;
 }
 
+- (void)setupDisplayLink {
+    if (_displayLink != NULL) {
+        CVDisplayLinkStop(_displayLink);
+        CVDisplayLinkRelease(_displayLink);
+        _displayLink = NULL;
+    }
+    CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
+    CVDisplayLinkSetOutputCallback(_displayLink, &displayLinkCallback, (__bridge void *)self);
+    CVDisplayLinkStart(_displayLink);
+}
+
+- (void)startDisplayLink {
+    os_unfair_lock_lock(&_displayStateLock);
+    _displayState.dirty = NO;
+    _displayState.window = _window;
+    os_unfair_lock_unlock(&_displayStateLock);
+}
+
+- (void)stopDisplayLink {
+    os_unfair_lock_lock(&_displayStateLock);
+    _displayState.dirty = NO;
+    _displayState.window = NULL;
+    os_unfair_lock_unlock(&_displayStateLock);
+}
+
+- (void)updatePosition:(NSPoint)position {
+    os_unfair_lock_lock(&_displayStateLock);
+    _displayState.position = position;
+    _displayState.operation = EMROperationMove;
+    _displayState.dirty = YES;
+    os_unfair_lock_unlock(&_displayStateLock);
+}
+
+- (void)updatePositionAndSize:(NSPoint)position size:(NSSize)size resizeSection:(struct ResizeSection)resizeSection {
+    os_unfair_lock_lock(&_displayStateLock);
+    _displayState.position = position;
+    _displayState.size = size;
+    _displayState.resizeSection = resizeSection;
+    _displayState.operation = EMROperationResize;
+    _displayState.dirty = YES;
+    os_unfair_lock_unlock(&_displayStateLock);
+}
+
+- (void)applyPendingChanges {
+    os_unfair_lock_lock(&_displayStateLock);
+    EMRDisplayState snapshot = _displayState;
+    _displayState.dirty = NO;
+    os_unfair_lock_unlock(&_displayStateLock);
+
+    if (!snapshot.dirty || snapshot.window == NULL) {
+        return;
+    }
+
+    if (snapshot.operation == EMROperationMove) {
+        CFTypeRef _position = (CFTypeRef)(AXValueCreate(kAXValueCGPointType, (const void *)&snapshot.position));
+        AXUIElementSetAttributeValue(snapshot.window, (__bridge CFStringRef)NSAccessibilityPositionAttribute, (CFTypeRef *)_position);
+        if (_position != NULL) CFRelease(_position);
+    } else if (snapshot.operation == EMROperationResize) {
+        if (snapshot.resizeSection.xResizeDirection == left || snapshot.resizeSection.yResizeDirection == bottom) {
+            CFTypeRef _position = (CFTypeRef)(AXValueCreate(kAXValueCGPointType, (const void *)&snapshot.position));
+            AXUIElementSetAttributeValue(snapshot.window, (__bridge CFStringRef)NSAccessibilityPositionAttribute, (CFTypeRef *)_position);
+            CFRelease(_position);
+        }
+
+        CFTypeRef _size = (CFTypeRef)(AXValueCreate(kAXValueCGSizeType, (const void *)&snapshot.size));
+        AXUIElementSetAttributeValue(snapshot.window, (__bridge CFStringRef)NSAccessibilitySizeAttribute, (CFTypeRef *)_size);
+        CFRelease(_size);
+    }
+}
+
 - (void)dealloc {
+    if (_displayLink != NULL) {
+        CVDisplayLinkStop(_displayLink);
+        CVDisplayLinkRelease(_displayLink);
+        _displayLink = NULL;
+    }
     if (_window != nil) CFRelease(_window);
 }
 


### PR DESCRIPTION
Long-time user, first contribution. I noticed window dragging felt slightly off compared to native macOS dragging and traced it to the timer-based throttling firing out of sync with the display. This replaces it with CVDisplayLink so updates land on frame boundaries. The before/after video shows the difference (maybe it isn't so perceptible due to compression and can be seen better if compiled and run). I tested it on my machine, a M4 Air.

https://github.com/user-attachments/assets/fefacde9-800a-4fde-a811-bffcc7210084

## What changed

Previously, move/resize events were throttled using `CACurrentMediaTime()` compared against a fixed interval. Updates fired independently of the display refresh cycle (note that this is different from refresh rate), causing visible jitter during window drag and resizing. I changed `project.pbxproj` because I needed to add the CoreVideo Framework to the project.

This PR introduces a producer/consumer architecture synchronized with vsync via `CVDisplayLink` API:

- The `CGEvent` callback writes the desired window state to a shared `EMRDisplayState` struct (protected by `os_unfair_lock`) and returns immediately — avoiding the ~1s watchdog timeout that would disable the event tap
- A `CVDisplayLink` callback fires once per display frame and applies the pending `AXUIElementSetAttributeValue` position/size changes

`CVDisplayLink` is created for the active displays at launch. When the display configuration changes (e.g. connecting an external monitor), the existing link becomes stale and needs to be recreated. Otherwise it fires with a zero interval, spiking WindowServer CPU. This is handled by listening to `NSApplicationDidChangeScreenParametersNotification`. I discovered this problem after plugging and using the application in an external monitor and seeing the WindowServer logs with `log show --predicate 'process == "WindowServer"'`. It's fixed now.

The original timer interval was derived from the display refresh rate but fired independently of vsync. The new approach fires exactly when the monitor updates, which decreases the jitter.